### PR TITLE
docs: expand README and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 LoRaATX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # loraatx.github.io
-Homepage for loraatx
+
+LoRaATX's public website and the home of its Kickstarter campaign.
+
+## Project Purpose
+
+LoRaATX aims to build a community-owned, citywide LoRaWAN network in Austin, Texas. This repository holds the static site that promotes the project and shares updates.
+
+## Technology Stack & Deployment
+
+The site is built with plain HTML and CSS and is deployed through GitHub Pages. Pushing changes to the `main` branch publishes them to the live site at `https://loraatx.github.io`.
+
+## Editing & Previewing Locally
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/loraatx/loraatx.github.io.git
+   cd loraatx.github.io
+   ```
+2. Modify `index.html` or other site files.
+3. Preview the site locally:
+   ```bash
+   python3 -m http.server
+   ```
+   Then visit [http://localhost:8000](http://localhost:8000) in your browser.
+
+## Contributing
+
+Contributions are welcome! Fork the repository, create a branch for your changes, and open a pull request for review.
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- detail project purpose, stack, and GitHub Pages deployment
- document local preview workflow
- add contributing guidelines and MIT license

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a749a4aba8832aab0bca2cd43ce978