### PR TITLE
feat: preconnect to tile server

### DIFF
--- a/projects/austin-3d/index.html
+++ b/projects/austin-3d/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
     <title>Austin 3D Map</title>
 
+    <link rel="preconnect" href="https://tiles.openfreemap.org" crossorigin>
+
     <!-- MapLibre via CDN -->
     <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.css"/>
     <script src="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.js"></script>


### PR DESCRIPTION
## Summary
- preconnect to OpenFreeMap tile server in Austin 3D project

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a89391c160832aa8ed8d4df24a22dd