### PR TITLE
feat: add map loading indicator

### DIFF
--- a/projects/_starter/app.js
+++ b/projects/_starter/app.js
@@ -34,6 +34,19 @@ let map = new maplibregl.Map({
   attributionControl: false
 });
 
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
 function syncLabels() {

--- a/projects/austin-3d/app.js
+++ b/projects/austin-3d/app.js
@@ -34,6 +34,19 @@ let map = new maplibregl.Map({
   attributionControl: false
 });
 
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
 function syncLabels() {


### PR DESCRIPTION
## Summary
- show loading state in map attribution while tiles fetch
- reset attribution on idle or display an error message if style fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a894637370832a8392698e5e2338f3