### PR TITLE
Add three project apps and link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,9 @@
   <h2 style="margin:0 0 12px 0;">Projects</h2>
   <ul style="margin:0; padding-left: 18px;">
     <li><a href="/projects/austin-3d/">Austin 3D Map</a></li>
+    <li><a href="/projects/lorawan/">LoRaWAN Map</a></li>
+    <li><a href="/projects/austin-planning/">Austin Planning Map</a></li>
+    <li><a href="/projects/city-coin/">City Coin Map</a></li>
   </ul>
 </section>
 

--- a/projects/austin-planning/app.js
+++ b/projects/austin-planning/app.js
@@ -1,0 +1,111 @@
+// Minimal MapLibre app with style switching + basic controls.
+
+const mapContainer = document.getElementById("mapCanvas");
+const styleSelect = document.getElementById("style");
+const styleUrlInput = document.getElementById("styleUrl");
+const pitchInput = document.getElementById("pitch");
+const bearingInput = document.getElementById("bearing");
+const zoomInput = document.getElementById("zoom");
+const pitchVal = document.getElementById("pitchVal");
+const bearingVal = document.getElementById("bearingVal");
+const zoomVal = document.getElementById("zoomVal");
+const goBtn = document.getElementById("go");
+const searchBox = document.getElementById("search");
+
+const VERSION = "2025-08-22";
+const STYLE_REGISTRY = {
+  OFM_3D: `https://tiles.openfreemap.org/styles/liberty?v=${VERSION}`,
+  OFM_2D: `https://tiles.openfreemap.org/styles/positron?v=${VERSION}`
+};
+
+function resolveStyle() {
+  const choice = styleSelect.value;
+  if (choice === "CUSTOM") return styleUrlInput.value.trim();
+  return STYLE_REGISTRY[choice];
+}
+
+let map = new maplibregl.Map({
+  container: mapContainer,
+  style: resolveStyle(),
+  center: [-97.7431, 30.2672], // Austin
+  zoom: Number(zoomInput.value),
+  pitch: Number(pitchInput.value),
+  bearing: Number(bearingInput.value),
+  attributionControl: false
+});
+
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
+map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
+
+function syncLabels() {
+  pitchVal.textContent = `${pitchInput.value}°`;
+  bearingVal.textContent = `${bearingInput.value}°`;
+  zoomVal.textContent = `z${zoomInput.value}`;
+}
+syncLabels();
+
+pitchInput.addEventListener("input", () => { map.setPitch(Number(pitchInput.value)); syncLabels(); });
+bearingInput.addEventListener("input", () => { map.setBearing(Number(bearingInput.value)); syncLabels(); });
+zoomInput.addEventListener("input", () => { map.setZoom(Number(zoomInput.value)); syncLabels(); });
+
+styleSelect.addEventListener("change", () => {
+  const newStyle = resolveStyle();
+  if (newStyle) map.setStyle(newStyle);
+});
+
+styleUrlInput.addEventListener("change", () => {
+  if (styleSelect.value === "CUSTOM") {
+    const custom = styleUrlInput.value.trim();
+    if (custom) map.setStyle(custom);
+  }
+});
+
+goBtn.addEventListener("click", () => {
+  const raw = searchBox.value.trim();
+  if (!raw) return;
+  const [lat, lng] = raw.split(",").map(s => Number(s.trim()));
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), 12), essential: true });
+  } else {
+    alert("Please enter coordinates like: 30.2672,-97.7431");
+  }
+});
+
+// Auto-enable terrain if the style includes a DEM source.
+map.on("styledata", () => {
+  try {
+    const style = map.getStyle();
+    const sources = style && style.sources ? style.sources : {};
+    const demKey = Object.keys(sources).find(k => sources[k].type === "raster-dem");
+    map.setTerrain(demKey ? { source: demKey } : null);
+  } catch (_) {}
+});
+
+// Helper for adding a GeoJSON overlay from a URL (no persistence)
+export async function addGeoJsonOverlay(url, id = "overlay") {
+  const res = await fetch(url);
+  const geojson = await res.json();
+
+  if (map.getLayer(id)) map.removeLayer(id);
+  if (map.getSource(id)) map.removeSource(id);
+
+  map.addSource(id, { type: "geojson", data: geojson });
+  map.addLayer({
+    id,
+    type: "circle",
+    source: id,
+    paint: { "circle-radius": 4, "circle-opacity": 0.85 }
+  });
+}

--- a/projects/austin-planning/index.html
+++ b/projects/austin-planning/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+    <title>Austin Planning Map</title>
+
+    <!-- MapLibre via CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.css"/>
+    <script src="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.js"></script>
+
+    <link rel="stylesheet" href="./styles.css" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #app { display: grid; grid-template-columns: 320px 1fr; height: 100%; }
+      #controls { padding: 12px; border-right: 1px solid #ddd; overflow: auto; }
+      #map { position: relative; }
+      #mapCanvas { position: absolute; inset: 0; }
+      .row { margin-bottom: 12px; }
+      label { display: block; font: 600 12px/1.4 system-ui, sans-serif; margin-bottom: 6px; }
+      select, input[type="range"], input[type="text"], button { width: 100%; padding: 8px; font: 12px system-ui, sans-serif; }
+      .fine { font: 11px/1.4 system-ui, sans-serif; color: #666; }
+      .attribution { position: absolute; bottom: 8px; right: 8px; background: rgba(255,255,255,0.85); padding: 6px 8px; border-radius: 4px; font: 11px/1.3 system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <aside id="controls">
+        <div class="row">
+          <label for="style">Basemap style</label>
+          <select id="style">
+            <option value="OFM_3D">OpenFreeMap – 3D (terrain)</option>
+            <option value="OFM_2D">OpenFreeMap – 2D</option>
+            <option value="CUSTOM">Custom (enter URL below)</option>
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="styleUrl">Custom style URL</label>
+          <input id="styleUrl" type="text" placeholder="https://.../style.json" />
+        </div>
+
+        <div class="row">
+          <label>View</label>
+          <label for="pitch">Pitch <span id="pitchVal" class="fine"></span></label>
+          <input id="pitch" type="range" min="0" max="85" value="60" />
+          <label for="bearing">Bearing <span id="bearingVal" class="fine"></span></label>
+          <input id="bearing" type="range" min="0" max="359" value="0" />
+          <label for="zoom">Zoom <span id="zoomVal" class="fine"></span></label>
+          <input id="zoom" type="range" min="1" max="20" value="13" />
+        </div>
+
+        <div class="row">
+          <label>Jump to</label>
+          <input id="search" type="text" placeholder="lat,lng (e.g. 30.2672,-97.7431)" />
+          <button id="go">Go</button>
+        </div>
+
+        <div class="row fine">
+          Client-only app. No data is written anywhere.
+        </div>
+      </aside>
+
+      <main id="map">
+        <div id="mapCanvas"></div>
+        <div class="attribution" id="attrib">© OpenStreetMap contributors</div>
+      </main>
+    </div>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/projects/austin-planning/styles.css
+++ b/projects/austin-planning/styles.css
@@ -1,0 +1,1 @@
+/* Optional project-specific styles */

--- a/projects/city-coin/app.js
+++ b/projects/city-coin/app.js
@@ -1,0 +1,111 @@
+// Minimal MapLibre app with style switching + basic controls.
+
+const mapContainer = document.getElementById("mapCanvas");
+const styleSelect = document.getElementById("style");
+const styleUrlInput = document.getElementById("styleUrl");
+const pitchInput = document.getElementById("pitch");
+const bearingInput = document.getElementById("bearing");
+const zoomInput = document.getElementById("zoom");
+const pitchVal = document.getElementById("pitchVal");
+const bearingVal = document.getElementById("bearingVal");
+const zoomVal = document.getElementById("zoomVal");
+const goBtn = document.getElementById("go");
+const searchBox = document.getElementById("search");
+
+const VERSION = "2025-08-22";
+const STYLE_REGISTRY = {
+  OFM_3D: `https://tiles.openfreemap.org/styles/liberty?v=${VERSION}`,
+  OFM_2D: `https://tiles.openfreemap.org/styles/positron?v=${VERSION}`
+};
+
+function resolveStyle() {
+  const choice = styleSelect.value;
+  if (choice === "CUSTOM") return styleUrlInput.value.trim();
+  return STYLE_REGISTRY[choice];
+}
+
+let map = new maplibregl.Map({
+  container: mapContainer,
+  style: resolveStyle(),
+  center: [-97.7431, 30.2672], // Austin
+  zoom: Number(zoomInput.value),
+  pitch: Number(pitchInput.value),
+  bearing: Number(bearingInput.value),
+  attributionControl: false
+});
+
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
+map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
+
+function syncLabels() {
+  pitchVal.textContent = `${pitchInput.value}°`;
+  bearingVal.textContent = `${bearingInput.value}°`;
+  zoomVal.textContent = `z${zoomInput.value}`;
+}
+syncLabels();
+
+pitchInput.addEventListener("input", () => { map.setPitch(Number(pitchInput.value)); syncLabels(); });
+bearingInput.addEventListener("input", () => { map.setBearing(Number(bearingInput.value)); syncLabels(); });
+zoomInput.addEventListener("input", () => { map.setZoom(Number(zoomInput.value)); syncLabels(); });
+
+styleSelect.addEventListener("change", () => {
+  const newStyle = resolveStyle();
+  if (newStyle) map.setStyle(newStyle);
+});
+
+styleUrlInput.addEventListener("change", () => {
+  if (styleSelect.value === "CUSTOM") {
+    const custom = styleUrlInput.value.trim();
+    if (custom) map.setStyle(custom);
+  }
+});
+
+goBtn.addEventListener("click", () => {
+  const raw = searchBox.value.trim();
+  if (!raw) return;
+  const [lat, lng] = raw.split(",").map(s => Number(s.trim()));
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), 12), essential: true });
+  } else {
+    alert("Please enter coordinates like: 30.2672,-97.7431");
+  }
+});
+
+// Auto-enable terrain if the style includes a DEM source.
+map.on("styledata", () => {
+  try {
+    const style = map.getStyle();
+    const sources = style && style.sources ? style.sources : {};
+    const demKey = Object.keys(sources).find(k => sources[k].type === "raster-dem");
+    map.setTerrain(demKey ? { source: demKey } : null);
+  } catch (_) {}
+});
+
+// Helper for adding a GeoJSON overlay from a URL (no persistence)
+export async function addGeoJsonOverlay(url, id = "overlay") {
+  const res = await fetch(url);
+  const geojson = await res.json();
+
+  if (map.getLayer(id)) map.removeLayer(id);
+  if (map.getSource(id)) map.removeSource(id);
+
+  map.addSource(id, { type: "geojson", data: geojson });
+  map.addLayer({
+    id,
+    type: "circle",
+    source: id,
+    paint: { "circle-radius": 4, "circle-opacity": 0.85 }
+  });
+}

--- a/projects/city-coin/index.html
+++ b/projects/city-coin/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+    <title>City Coin Map</title>
+
+    <!-- MapLibre via CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.css"/>
+    <script src="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.js"></script>
+
+    <link rel="stylesheet" href="./styles.css" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #app { display: grid; grid-template-columns: 320px 1fr; height: 100%; }
+      #controls { padding: 12px; border-right: 1px solid #ddd; overflow: auto; }
+      #map { position: relative; }
+      #mapCanvas { position: absolute; inset: 0; }
+      .row { margin-bottom: 12px; }
+      label { display: block; font: 600 12px/1.4 system-ui, sans-serif; margin-bottom: 6px; }
+      select, input[type="range"], input[type="text"], button { width: 100%; padding: 8px; font: 12px system-ui, sans-serif; }
+      .fine { font: 11px/1.4 system-ui, sans-serif; color: #666; }
+      .attribution { position: absolute; bottom: 8px; right: 8px; background: rgba(255,255,255,0.85); padding: 6px 8px; border-radius: 4px; font: 11px/1.3 system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <aside id="controls">
+        <div class="row">
+          <label for="style">Basemap style</label>
+          <select id="style">
+            <option value="OFM_3D">OpenFreeMap – 3D (terrain)</option>
+            <option value="OFM_2D">OpenFreeMap – 2D</option>
+            <option value="CUSTOM">Custom (enter URL below)</option>
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="styleUrl">Custom style URL</label>
+          <input id="styleUrl" type="text" placeholder="https://.../style.json" />
+        </div>
+
+        <div class="row">
+          <label>View</label>
+          <label for="pitch">Pitch <span id="pitchVal" class="fine"></span></label>
+          <input id="pitch" type="range" min="0" max="85" value="60" />
+          <label for="bearing">Bearing <span id="bearingVal" class="fine"></span></label>
+          <input id="bearing" type="range" min="0" max="359" value="0" />
+          <label for="zoom">Zoom <span id="zoomVal" class="fine"></span></label>
+          <input id="zoom" type="range" min="1" max="20" value="13" />
+        </div>
+
+        <div class="row">
+          <label>Jump to</label>
+          <input id="search" type="text" placeholder="lat,lng (e.g. 30.2672,-97.7431)" />
+          <button id="go">Go</button>
+        </div>
+
+        <div class="row fine">
+          Client-only app. No data is written anywhere.
+        </div>
+      </aside>
+
+      <main id="map">
+        <div id="mapCanvas"></div>
+        <div class="attribution" id="attrib">© OpenStreetMap contributors</div>
+      </main>
+    </div>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/projects/city-coin/styles.css
+++ b/projects/city-coin/styles.css
@@ -1,0 +1,1 @@
+/* Optional project-specific styles */

--- a/projects/lorawan/app.js
+++ b/projects/lorawan/app.js
@@ -1,0 +1,111 @@
+// Minimal MapLibre app with style switching + basic controls.
+
+const mapContainer = document.getElementById("mapCanvas");
+const styleSelect = document.getElementById("style");
+const styleUrlInput = document.getElementById("styleUrl");
+const pitchInput = document.getElementById("pitch");
+const bearingInput = document.getElementById("bearing");
+const zoomInput = document.getElementById("zoom");
+const pitchVal = document.getElementById("pitchVal");
+const bearingVal = document.getElementById("bearingVal");
+const zoomVal = document.getElementById("zoomVal");
+const goBtn = document.getElementById("go");
+const searchBox = document.getElementById("search");
+
+const VERSION = "2025-08-22";
+const STYLE_REGISTRY = {
+  OFM_3D: `https://tiles.openfreemap.org/styles/liberty?v=${VERSION}`,
+  OFM_2D: `https://tiles.openfreemap.org/styles/positron?v=${VERSION}`
+};
+
+function resolveStyle() {
+  const choice = styleSelect.value;
+  if (choice === "CUSTOM") return styleUrlInput.value.trim();
+  return STYLE_REGISTRY[choice];
+}
+
+let map = new maplibregl.Map({
+  container: mapContainer,
+  style: resolveStyle(),
+  center: [-97.7431, 30.2672], // Austin
+  zoom: Number(zoomInput.value),
+  pitch: Number(pitchInput.value),
+  bearing: Number(bearingInput.value),
+  attributionControl: false
+});
+
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
+map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
+
+function syncLabels() {
+  pitchVal.textContent = `${pitchInput.value}°`;
+  bearingVal.textContent = `${bearingInput.value}°`;
+  zoomVal.textContent = `z${zoomInput.value}`;
+}
+syncLabels();
+
+pitchInput.addEventListener("input", () => { map.setPitch(Number(pitchInput.value)); syncLabels(); });
+bearingInput.addEventListener("input", () => { map.setBearing(Number(bearingInput.value)); syncLabels(); });
+zoomInput.addEventListener("input", () => { map.setZoom(Number(zoomInput.value)); syncLabels(); });
+
+styleSelect.addEventListener("change", () => {
+  const newStyle = resolveStyle();
+  if (newStyle) map.setStyle(newStyle);
+});
+
+styleUrlInput.addEventListener("change", () => {
+  if (styleSelect.value === "CUSTOM") {
+    const custom = styleUrlInput.value.trim();
+    if (custom) map.setStyle(custom);
+  }
+});
+
+goBtn.addEventListener("click", () => {
+  const raw = searchBox.value.trim();
+  if (!raw) return;
+  const [lat, lng] = raw.split(",").map(s => Number(s.trim()));
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), 12), essential: true });
+  } else {
+    alert("Please enter coordinates like: 30.2672,-97.7431");
+  }
+});
+
+// Auto-enable terrain if the style includes a DEM source.
+map.on("styledata", () => {
+  try {
+    const style = map.getStyle();
+    const sources = style && style.sources ? style.sources : {};
+    const demKey = Object.keys(sources).find(k => sources[k].type === "raster-dem");
+    map.setTerrain(demKey ? { source: demKey } : null);
+  } catch (_) {}
+});
+
+// Helper for adding a GeoJSON overlay from a URL (no persistence)
+export async function addGeoJsonOverlay(url, id = "overlay") {
+  const res = await fetch(url);
+  const geojson = await res.json();
+
+  if (map.getLayer(id)) map.removeLayer(id);
+  if (map.getSource(id)) map.removeSource(id);
+
+  map.addSource(id, { type: "geojson", data: geojson });
+  map.addLayer({
+    id,
+    type: "circle",
+    source: id,
+    paint: { "circle-radius": 4, "circle-opacity": 0.85 }
+  });
+}

--- a/projects/lorawan/index.html
+++ b/projects/lorawan/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+    <title>LoRaWAN Map</title>
+
+    <!-- MapLibre via CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.css"/>
+    <script src="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.js"></script>
+
+    <link rel="stylesheet" href="./styles.css" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #app { display: grid; grid-template-columns: 320px 1fr; height: 100%; }
+      #controls { padding: 12px; border-right: 1px solid #ddd; overflow: auto; }
+      #map { position: relative; }
+      #mapCanvas { position: absolute; inset: 0; }
+      .row { margin-bottom: 12px; }
+      label { display: block; font: 600 12px/1.4 system-ui, sans-serif; margin-bottom: 6px; }
+      select, input[type="range"], input[type="text"], button { width: 100%; padding: 8px; font: 12px system-ui, sans-serif; }
+      .fine { font: 11px/1.4 system-ui, sans-serif; color: #666; }
+      .attribution { position: absolute; bottom: 8px; right: 8px; background: rgba(255,255,255,0.85); padding: 6px 8px; border-radius: 4px; font: 11px/1.3 system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <aside id="controls">
+        <div class="row">
+          <label for="style">Basemap style</label>
+          <select id="style">
+            <option value="OFM_3D">OpenFreeMap – 3D (terrain)</option>
+            <option value="OFM_2D">OpenFreeMap – 2D</option>
+            <option value="CUSTOM">Custom (enter URL below)</option>
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="styleUrl">Custom style URL</label>
+          <input id="styleUrl" type="text" placeholder="https://.../style.json" />
+        </div>
+
+        <div class="row">
+          <label>View</label>
+          <label for="pitch">Pitch <span id="pitchVal" class="fine"></span></label>
+          <input id="pitch" type="range" min="0" max="85" value="60" />
+          <label for="bearing">Bearing <span id="bearingVal" class="fine"></span></label>
+          <input id="bearing" type="range" min="0" max="359" value="0" />
+          <label for="zoom">Zoom <span id="zoomVal" class="fine"></span></label>
+          <input id="zoom" type="range" min="1" max="20" value="13" />
+        </div>
+
+        <div class="row">
+          <label>Jump to</label>
+          <input id="search" type="text" placeholder="lat,lng (e.g. 30.2672,-97.7431)" />
+          <button id="go">Go</button>
+        </div>
+
+        <div class="row fine">
+          Client-only app. No data is written anywhere.
+        </div>
+      </aside>
+
+      <main id="map">
+        <div id="mapCanvas"></div>
+        <div class="attribution" id="attrib">© OpenStreetMap contributors</div>
+      </main>
+    </div>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/projects/lorawan/styles.css
+++ b/projects/lorawan/styles.css
@@ -1,0 +1,1 @@
+/* Optional project-specific styles */


### PR DESCRIPTION
## Summary
- create LoRaWAN, Austin Planning, and City Coin project apps from starter template
- configure OpenFreeMap style registry for new apps and update HTML titles
- link new apps from the homepage project list

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a896d44d64832aba18b75fd3c7cf74