### PR TITLE
Add geolocation control to project maps

### DIFF
--- a/projects/_starter/app.js
+++ b/projects/_starter/app.js
@@ -49,6 +49,15 @@ map.on("error", e => {
 
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+
 function syncLabels() {
   pitchVal.textContent = `${pitchInput.value}°`;
   bearingVal.textContent = `${bearingInput.value}°`;

--- a/projects/austin-3d/app.js
+++ b/projects/austin-3d/app.js
@@ -79,6 +79,15 @@ map.on("error", e => {
 
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+
 function syncLabels() {
   pitchVal.textContent = `${pitchInput.value}°`;
   bearingVal.textContent = `${bearingInput.value}°`;

--- a/projects/austin-planning/app.js
+++ b/projects/austin-planning/app.js
@@ -49,6 +49,15 @@ map.on("error", e => {
 
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+
 function syncLabels() {
   pitchVal.textContent = `${pitchInput.value}°`;
   bearingVal.textContent = `${bearingInput.value}°`;

--- a/projects/city-coin/app.js
+++ b/projects/city-coin/app.js
@@ -49,6 +49,15 @@ map.on("error", e => {
 
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+
 function syncLabels() {
   pitchVal.textContent = `${pitchInput.value}°`;
   bearingVal.textContent = `${bearingInput.value}°`;

--- a/projects/lorawan/app.js
+++ b/projects/lorawan/app.js
@@ -49,6 +49,15 @@ map.on("error", e => {
 
 map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), "top-right");
 
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+
 function syncLabels() {
   pitchVal.textContent = `${pitchInput.value}°`;
   bearingVal.textContent = `${bearingInput.value}°`;


### PR DESCRIPTION
## Summary
- add MapLibre GeolocateControl to each project map script
- trigger geolocation on map load for immediate zoom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b60c8f8c832a86aafbe7e942c8b0