### PR TITLE
Fix breadcrumbs and restore map navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
   <h2 style="margin:0 0 12px 0;">Projects</h2>
   <ul style="margin:0; padding-left: 18px;">
     <li><a href="/projects/apps/austin-3d/">Austin 3D Map</a></li>
+    <li><a href="/projects/apps/kml-viewer/">KML Viewer</a></li>
   </ul>
 </section>
 

--- a/projects/apps/_starter/index.html
+++ b/projects/apps/_starter/index.html
@@ -137,7 +137,7 @@
         <div class="row fine">
           Client-only app. No data is written anywhere.
         </div>
-        <footer class="fine"><a href="/projects/">&larr; Back to Projects</a></footer>
+        <footer class="fine"><a href="/projects/apps/">&larr; Back to Apps</a></footer>
       </aside>
 
       <main id="map">

--- a/projects/apps/index.html
+++ b/projects/apps/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="_starter/">_starter/</a></li>
     <li><a href="austin-3d/">austin-3d/</a></li>
+    <li><a href="kml-viewer/">kml-viewer/</a></li>
   </ul>
 </body>
 </html>

--- a/projects/apps/kml-viewer/app.js
+++ b/projects/apps/kml-viewer/app.js
@@ -1,0 +1,153 @@
+// Minimal MapLibre app with style switching + basic controls.
+
+const mapContainer = document.getElementById("mapCanvas");
+const styleSelect = document.getElementById("style");
+const styleUrlInput = document.getElementById("styleUrl");
+const goBtn = document.getElementById("go");
+const searchBox = document.getElementById("search");
+
+function readParams() {
+  const u = new URL(location.href);
+  const g = (k, d) => Number(u.searchParams.get(k) ?? d);
+  const s = u.searchParams.get("style");
+  return {
+    center: [g("lng", -97.7431), g("lat", 30.2672)],
+    zoom: g("z", 13), pitch: g("p", 60), bearing: g("b", 0),
+    style: s
+  };
+}
+function writeParams() {
+  const u = new URL(location.href);
+  const c = map.getCenter();
+  u.searchParams.set("lat", c.lat.toFixed(5));
+  u.searchParams.set("lng", c.lng.toFixed(5));
+  u.searchParams.set("z", map.getZoom().toFixed(2));
+  u.searchParams.set("p", map.getPitch().toFixed(0));
+  u.searchParams.set("b", map.getBearing().toFixed(0));
+  u.searchParams.set("style", styleSelect.value);
+  history.replaceState({}, "", u);
+}
+
+// Replace these placeholders with real OpenFreeMap style URLs later.
+const STYLE_REGISTRY = {
+  OFM_3D: "https://tiles.openfreemap.org/styles/liberty",   // 3D buildings via extrusions
+  OFM_2D: "https://tiles.openfreemap.org/styles/positron"   // crisp 2D
+};
+
+const init = readParams();
+if (init.style && STYLE_REGISTRY[init.style]) styleSelect.value = init.style;
+
+function resolveStyle() {
+  const choice = styleSelect.value;
+  if (choice === "CUSTOM") return styleUrlInput.value.trim();
+  return STYLE_REGISTRY[choice];
+}
+
+let map = new maplibregl.Map({
+  container: mapContainer,
+  style: resolveStyle(),
+  center: init.center,
+  zoom: init.zoom,
+  pitch: init.pitch,
+  bearing: init.bearing,
+  attributionControl: false
+});
+
+map.setPitch(init.pitch); map.setBearing(init.bearing); map.setZoom(init.zoom); map.setCenter(init.center);
+
+map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }), 'top-right');
+
+const attrib = document.getElementById("attrib");
+function showMsg(msg) {
+  attrib.textContent = msg;
+  setTimeout(() => attrib.textContent = "© OpenStreetMap contributors", 2000);
+}
+
+map.on("dataloading", () => attrib.textContent = "Loading map…");
+map.on("idle", () => attrib.textContent = "© OpenStreetMap contributors");
+map.on("error", e => {
+  console.error(e);
+  showMsg("Map style error — check console");
+});
+
+const geolocate = new maplibregl.GeolocateControl({
+  positionOptions: { enableHighAccuracy: true },
+  trackUserLocation: false,          // set true to keep following the user
+  showUserHeading: true              // optional: shows direction arrow
+});
+map.addControl(geolocate, 'top-right');
+
+map.on('load', () => geolocate.trigger());
+["moveend","pitchend","rotateend","zoomend"].forEach(evt => map.on(evt, writeParams));
+
+styleSelect.addEventListener("change", () => {
+  const newStyle = resolveStyle();
+  if (newStyle) map.setStyle(newStyle);
+});
+styleSelect.addEventListener("change", writeParams);
+
+styleUrlInput.addEventListener("change", () => {
+  if (styleSelect.value === "CUSTOM") {
+    const custom = styleUrlInput.value.trim();
+    if (custom) map.setStyle(custom);
+  }
+});
+
+goBtn.addEventListener("click", () => {
+  const raw = searchBox.value.trim();
+  if (!raw) return;
+  const [lat, lng] = raw.split(",").map(s => Number(s.trim()));
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    map.flyTo({ center: [lng, lat], zoom: Math.max(map.getZoom(), 12), essential: true });
+  } else {
+    alert("Please enter coordinates like: 30.2672,-97.7431");
+  }
+});
+
+async function addKml(source) {
+  const xml = typeof source === "string"
+    ? await (await fetch(source)).text()
+    : await source.text();
+  const dom = new DOMParser().parseFromString(xml, "text/xml");
+  const geojson = toGeoJSON.kml(dom);
+
+  const id = "kml";
+  if (map.getLayer(id)) map.removeLayer(id);
+  if (map.getSource(id)) map.removeSource(id);
+  map.addSource(id, { type: "geojson", data: geojson });
+  map.addLayer({ id, type: "line", source: id, paint: { "line-color": "#f00" } });
+}
+
+document.getElementById("loadKml").onclick = () =>
+  addKml(document.getElementById("kmlUrl").value.trim());
+
+document.getElementById("kmlFile").onchange = e =>
+  addKml(e.target.files[0]);
+
+// Auto-enable terrain if the style includes a DEM source.
+map.on("styledata", () => {
+  try {
+    const style = map.getStyle();
+    const sources = style && style.sources ? style.sources : {};
+    const demKey = Object.keys(sources).find(k => sources[k].type === "raster-dem");
+    map.setTerrain(demKey ? { source: demKey } : null);
+  } catch (_) {}
+});
+
+// Helper for adding a GeoJSON overlay from a URL (no persistence)
+export async function addGeoJsonOverlay(url, id = "overlay") {
+  const res = await fetch(url);
+  const geojson = await res.json();
+
+  if (map.getLayer(id)) map.removeLayer(id);
+  if (map.getSource(id)) map.removeSource(id);
+
+  map.addSource(id, { type: "geojson", data: geojson });
+  map.addLayer({
+    id,
+    type: "circle",
+    source: id,
+    paint: { "circle-radius": 4, "circle-opacity": 0.85 }
+  });
+}
+

--- a/projects/apps/kml-viewer/index.html
+++ b/projects/apps/kml-viewer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Austin 3D Map</title>
+    <title>KML Viewer</title>
 
     <!-- Perf: warm up tile host -->
     <link rel="preconnect" href="https://tiles.openfreemap.org" crossorigin>
@@ -12,6 +12,7 @@
     <!-- MapLibre -->
     <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.css" />
     <script src="https://unpkg.com/maplibre-gl@^3.6.0/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/@tmcw/togeojson@4"></script>
 
     <!-- Optional project styles -->
     <link rel="stylesheet" href="./styles.css" />
@@ -119,19 +120,17 @@
         </div>
 
         <div class="row">
-          <label>View</label>
-          <label for="pitch">Pitch <span id="pitchVal" class="fine"></span></label>
-          <input id="pitch" type="range" min="0" max="85" value="60" />
-          <label for="bearing">Bearing <span id="bearingVal" class="fine"></span></label>
-          <input id="bearing" type="range" min="0" max="359" value="0" />
-          <label for="zoom">Zoom <span id="zoomVal" class="fine"></span></label>
-          <input id="zoom" type="range" min="1" max="20" value="13" />
-        </div>
-
-        <div class="row">
           <label>Jump to</label>
           <input id="search" type="text" placeholder="lat,lng (e.g. 30.2672,-97.7431)" />
           <button id="go">Go</button>
+        </div>
+
+        <div class="row">
+          <label for="kmlUrl">KML overlay URL</label>
+          <input id="kmlUrl" type="text" placeholder="https://.../file.kml" />
+          <button id="loadKml">Load KML</button>
+          <!-- optional local file -->
+          <input id="kmlFile" type="file" accept=".kml" />
         </div>
 
         <div class="row fine">

--- a/projects/apps/kml-viewer/styles.css
+++ b/projects/apps/kml-viewer/styles.css
@@ -1,0 +1,1 @@
+/* Optional project-specific styles */


### PR DESCRIPTION
## Summary
- link KML Viewer from home page project list
- point app footers back to Apps index
- re-enable zoom/bearing/pitch interactions and add navigation control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa09d17820832aa18577faade10483