### PR TITLE
Update app footer links to point to Apps section

### DIFF
--- a/projects/apps/_starter/index.html
+++ b/projects/apps/_starter/index.html
@@ -137,7 +137,7 @@
         <div class="row fine">
           Client-only app. No data is written anywhere.
         </div>
-        <footer class="fine"><a href="/projects/">&larr; Back to Projects</a></footer>
+        <footer class="fine"><a href="/projects/apps/">&larr; Back to Apps</a></footer>
       </aside>
 
       <main id="map">

--- a/projects/apps/austin-3d/index.html
+++ b/projects/apps/austin-3d/index.html
@@ -137,7 +137,7 @@
         <div class="row fine">
           Client-only app. No data is written anywhere.
         </div>
-        <footer class="fine"><a href="/projects/">&larr; Back to Projects</a></footer>
+        <footer class="fine"><a href="/projects/apps/">&larr; Back to Apps</a></footer>
       </aside>
 
       <main id="map">

--- a/projects/apps/kml-viewer/index.html
+++ b/projects/apps/kml-viewer/index.html
@@ -136,7 +136,7 @@
         <div class="row fine">
           Client-only app. No data is written anywhere.
         </div>
-        <footer class="fine"><a href="/projects/">&larr; Back to Projects</a></footer>
+        <footer class="fine"><a href="/projects/apps/">&larr; Back to Apps</a></footer>
       </aside>
 
       <main id="map">


### PR DESCRIPTION
## Summary
- adjust footer links in apps to point to `/projects/apps/`
- change link text to `← Back to Apps`

## Testing
- `python3 -m http.server`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af38b03f08832a8cdfc92fd74434de