### PR TITLE
Redesign landing page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,133 @@
+:root {
+  --rustic-clay: #B66B4A;
+  --golden-brown: #9C5F21;
+  --deep-walnut: #3E2617;
+  --bright-electric-blue: #0065CF;
+  --sky-blue: #3AA8F5;
+  --font-family: 'Roboto', Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  line-height: 1.6;
+  color: var(--deep-walnut);
+}
+
+.navbar {
+  background-color: var(--deep-walnut);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+.navbar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+.navbar a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.hero {
+  background-color: var(--rustic-clay);
+  color: #fff;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.hero h1 {
+  margin: 0 0 1rem 0;
+  font-size: 2.5rem;
+}
+
+.section {
+  padding: 4rem 1rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.section h2 {
+  margin-top: 0;
+  color: var(--golden-brown);
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+.project-card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.project-card img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.project-card h3 {
+  margin: 0.5rem 1rem;
+}
+.project-card p {
+  margin: 0 1rem 1rem;
+  font-size: 0.9rem;
+}
+.project-card a {
+  display: block;
+  margin: 0 1rem 1rem;
+  color: var(--bright-electric-blue);
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+.video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: var(--bright-electric-blue);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  margin-top: 1rem;
+}
+
+footer {
+  background-color: var(--deep-walnut);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+@media (max-width: 600px) {
+  .navbar ul {
+    flex-direction: column;
+  }
+  .hero {
+    padding: 2rem 1rem;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('assets/projects.json')
+    .then(response => response.json())
+    .then(projects => {
+      const grid = document.getElementById('project-grid');
+      if (!grid) return;
+      projects.forEach(project => {
+        const card = document.createElement('div');
+        card.className = 'project-card';
+        card.innerHTML = `
+          <img src="${project.image}" alt="${project.title}">
+          <h3>${project.title}</h3>
+          <p>${project.description}</p>
+          <a href="${project.link}" target="_blank" rel="noopener">View project</a>
+        `;
+        grid.appendChild(card);
+      });
+    })
+    .catch(err => console.error('Could not load projects', err));
+});

--- a/assets/projects.json
+++ b/assets/projects.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Austin 3D Map",
+    "link": "https://loraatx.github.io/austin-3d/",
+    "image": "https://via.placeholder.com/300x200?text=Austin+3D+Map",
+    "description": "Interactive 3D map of Austin showcasing LoRa coverage."
+  },
+  {
+    "title": "KML Viewer",
+    "link": "https://loraatx.github.io/kml-viewer/",
+    "image": "https://via.placeholder.com/300x200?text=KML+Viewer",
+    "description": "Tool for viewing KML datasets directly in the browser."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -3,132 +3,64 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LoRaATX - Kickstarter Campaign</title>
+    <title>LoRaATX</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-    <style>
-        body {
-            font-family: 'Roboto', Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            line-height: 1.6;
-            color: #333;
-        }
-        nav {
-            background-color: #f4f4f4;
-            padding: 1rem;
-        }
-        nav ul {
-            list-style: none;
-            display: flex;
-            justify-content: center;
-            gap: 1rem;
-            margin: 0;
-            padding: 0;
-        }
-        nav a {
-            text-decoration: none;
-            color: #333;
-        }
-        header {
-            background-color: #1a73e8;
-            color: white;
-            text-align: center;
-            padding: 2rem;
-        }
-        header h1 {
-            margin: 0;
-            font-size: 2.5rem;
-        }
-        .video-section {
-            max-width: 800px;
-            margin: 2rem auto;
-            padding: 0 1rem;
-        }
-        .video-container {
-            position: relative;
-            padding-bottom: 56.25%; /* 16:9 aspect ratio */
-            height: 0;
-            overflow: hidden;
-        }
-        .video-container iframe {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
-        .content-section {
-            max-width: 800px;
-            margin: 2rem auto;
-            padding: 0 1rem;
-        }
-        footer {
-            background-color: #f4f4f4;
-            text-align: center;
-            padding: 1rem;
-            position: relative;
-            bottom: 0;
-            width: 100%;
-        }
-    </style>
+    <link rel="stylesheet" href="assets/css/main.css">
+    <script src="assets/js/main.js" defer></script>
 </head>
 <body>
-    <nav>
+    <nav class="navbar">
         <ul>
-            <li><a href="#">Home</a></li>
-            <li><a href="#about">About</a></li>
-            <li><a href="#contact">Contact</a></li>
+            <li><a href="#apps">Apps</a></li>
+            <li><a href="#data">Data</a></li>
+            <li><a href="#services">Services</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#kickstarter">Kickstarter</a></li>
         </ul>
     </nav>
-    <header>
+
+    <header class="hero">
         <h1>LoRaATX</h1>
         <p>A license-free, open-source Internet of Things network covering all of Austin, Texas.</p>
     </header>
 
-    <section class="video-section">
+    <section id="apps" class="section">
+        <h2>Apps</h2>
+        <p>Placeholder for information about applications built on the LoRaATX network.</p>
+    </section>
+
+    <section id="data" class="section">
+        <h2>Data</h2>
+        <p>Placeholder for datasets and open data resources.</p>
+    </section>
+
+    <section id="services" class="section">
+        <h2>Services</h2>
+        <p>Placeholder for services offered by the LoRaATX community.</p>
+    </section>
+
+    <section id="projects" class="section">
+        <h2>Projects</h2>
+        <div id="project-grid" class="project-grid"></div>
+    </section>
+
+    <section id="kickstarter" class="section">
+        <h2>Kickstarter</h2>
+        <p>Support our campaign to build a city-wide IoT network for Austin.</p>
         <div class="video-container">
-            <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E" 
-                    title="LoRaATX Explainer Video" 
-                    frameborder="0" 
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-                    allowfullscreen>
-            </iframe>
+            <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E"
+                    title="LoRaATX Explainer Video"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
         </div>
-    </section>
-
-    <section class="content-section" id="about">
-        <h2>About LoRaATX</h2>
-        <p>LoRaATX.City hosts a Kickstarter campaign to explore how a long-range IoT network could benefit Austin.</p>
-        <p>The campaign aims to raise $12,000 to develop three pilot devices:</p>
-        <ul>
-            <li>A pet tracker</li>
-            <li>An inline scooter</li>
-            <li>A portable flood warning system</li>
-        </ul>
-        <p>This project is a proof of concept for a city-owned LoRaWAN network in Austin. The long-range, low-power system lets smart devices such as scooters, pet trackers, leak sensors, and air monitors connect without using cellular data.</p>
-        <p>Instead of relying on costly telecom services, the Kickstarter will fund a demonstration of how Austin could operate its own secure, low-frequency IoT network as a public utility.</p>
-        <p>We will outfit a scooter with LoRaWAN technology, transform an everyday pet collar into a tracker, and use a terrarium to showcase a LoRaWAN flood alert system.</p>
-        <p>The campaign will also support a temporary nonprofit to pursue federal grants and organize stakeholders. It is scheduled for August 2025.</p>
-    </section>
-
-    <section class="content-section" id="contact">
-        <h2>Contact</h2>
-        <p>For inquiries, please reach out to <a href="mailto:info@loraatx.city">info@loraatx.city</a>.</p>
+        <a href="https://www.kickstarter.com/" class="btn" target="_blank" rel="noopener">Visit Campaign</a>
     </section>
 
     <footer>
-        <p>&copy; 2025 LoRaATX. All rights reserved.</p>
+        <p>&copy; 2025 LoRaATX. All rights reserved. Contact <a href="mailto:info@loraatx.city" style="color: inherit; text-decoration: underline;">info@loraatx.city</a></p>
     </footer>
-<!-- Projects -->
-<section id="projects" style="padding:24px 16px; border-top:1px solid #eee; font: 14px/1.5 system-ui, sans-serif;">
-  <h2 style="margin:0 0 12px 0;">Projects</h2>
-  <ul style="margin:0; padding-left: 18px;">
-    <li><a href="https://loraatx.github.io/austin-3d/">Austin 3D Map</a></li>
-    <li><a href="https://loraatx.github.io/kml-viewer/">KML Viewer</a></li>
-  </ul>
-</section>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace inline styles with `assets/css/main.css` using Austin Long Range color palette
- Restructure `index.html` as a single-page site with Apps, Data, Services, Projects, and Kickstarter sections
- Dynamically render project cards from `assets/projects.json` via `assets/js/main.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21cc23ca4832a9d2a40dfc1c05552