### PR TITLE
feat: external stylesheet with responsive layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,125 @@
+:root {
+    --primary-color: #1a73e8;
+    --secondary-color: #f4f4f4;
+    --text-color: #333;
+    /* Additional theme variables can be added here */
+}
+
+body {
+    font-family: 'Roboto', Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    color: var(--text-color);
+}
+
+nav {
+    background-color: var(--secondary-color);
+    padding: 1rem;
+}
+
+nav ul {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+nav a {
+    text-decoration: none;
+    color: var(--text-color);
+}
+
+header {
+    background-color: var(--primary-color);
+    color: white;
+    text-align: center;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 2.5rem;
+}
+
+.video-section {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    display: flex;
+    justify-content: center;
+}
+
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+    width: 100%;
+}
+
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.content-section {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+footer {
+    background-color: var(--secondary-color);
+    text-align: center;
+    padding: 1rem;
+    position: relative;
+    bottom: 0;
+    width: 100%;
+}
+
+#projects {
+    padding: 24px 16px;
+    border-top: 1px solid #eee;
+    font: 14px/1.5 system-ui, sans-serif;
+}
+
+#projects h2 {
+    margin: 0 0 12px 0;
+}
+
+#projects ul {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+    header {
+        padding: 1.5rem;
+    }
+
+    header h1 {
+        font-size: 2rem;
+    }
+
+    .video-section {
+        margin: 1rem auto;
+    }
+
+    #projects {
+        padding: 16px 8px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -7,72 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-    <style>
-        body {
-            font-family: 'Roboto', Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            line-height: 1.6;
-            color: #333;
-        }
-        nav {
-            background-color: #f4f4f4;
-            padding: 1rem;
-        }
-        nav ul {
-            list-style: none;
-            display: flex;
-            justify-content: center;
-            gap: 1rem;
-            margin: 0;
-            padding: 0;
-        }
-        nav a {
-            text-decoration: none;
-            color: #333;
-        }
-        header {
-            background-color: #1a73e8;
-            color: white;
-            text-align: center;
-            padding: 2rem;
-        }
-        header h1 {
-            margin: 0;
-            font-size: 2.5rem;
-        }
-        .video-section {
-            max-width: 800px;
-            margin: 2rem auto;
-            padding: 0 1rem;
-        }
-        .video-container {
-            position: relative;
-            padding-bottom: 56.25%; /* 16:9 aspect ratio */
-            height: 0;
-            overflow: hidden;
-        }
-        .video-container iframe {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
-        .content-section {
-            max-width: 800px;
-            margin: 2rem auto;
-            padding: 0 1rem;
-        }
-        footer {
-            background-color: #f4f4f4;
-            text-align: center;
-            padding: 1rem;
-            position: relative;
-            bottom: 0;
-            width: 100%;
-        }
-    </style>
+    <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body>
     <nav>
@@ -122,9 +57,9 @@
         <p>&copy; 2025 LoRaATX. All rights reserved.</p>
     </footer>
 <!-- Projects -->
-<section id="projects" style="padding:24px 16px; border-top:1px solid #eee; font: 14px/1.5 system-ui, sans-serif;">
-  <h2 style="margin:0 0 12px 0;">Projects</h2>
-  <ul style="margin:0; padding-left: 18px;">
+<section id="projects">
+  <h2>Projects</h2>
+  <ul>
     <li><a href="https://loraatx.github.io/austin-3d/">Austin 3D Map</a></li>
     <li><a href="https://loraatx.github.io/kml-viewer/">KML Viewer</a></li>
   </ul>


### PR DESCRIPTION
## Summary
- move inline styles to `assets/css/main.css`
- add responsive flexbox and grid rules for header, video, and projects sections
- set up placeholders for future theme variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b281b52d68832abe2001291372c574