### PR TITLE
Add responsive video section with call-to-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,15 @@
             margin: 2rem auto;
             padding: 0 1rem;
         }
+        .cta-button {
+            display: inline-block;
+            margin-top: 1rem;
+            padding: 0.5rem 1rem;
+            background-color: #1a73e8;
+            color: #fff;
+            text-decoration: none;
+            border-radius: 4px;
+        }
         .video-container {
             position: relative;
             padding-bottom: 56.25%; /* 16:9 aspect ratio */
@@ -88,14 +97,17 @@
     </header>
 
     <section class="video-section">
+        <h2>Explainer Video</h2>
+        <p>Discover how LoRaATX aims to build an open-source network across Austin.</p>
         <div class="video-container">
-            <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E" 
-                    title="LoRaATX Explainer Video" 
-                    frameborder="0" 
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+            <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E"
+                    title="LoRaATX Explainer Video"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen>
             </iframe>
         </div>
+        <a class="cta-button" href="https://kickstarter.com/projects/loraatx">Support the Campaign</a>
     </section>
 
     <section class="content-section" id="about">


### PR DESCRIPTION
## Summary
- Wrap explainer video in a dedicated section with heading, description, and "Support the Campaign" button.
- Style new call-to-action button and preserve responsive 16:9 video scaling.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b281b9b180832ab4b37a0724652074