### PR TITLE
Link projects to standalone repos

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,21 +255,13 @@
         <p>Placeholder for services offered by the LoRaATX community.</p>
     </section>
 
-    <section id="projects" class="section">
-        <h2>Projects</h2>
-        <div id="project-grid" class="project-grid"></div>
-    </section>
     <section id="projects" class="content-section">
         <h2>Projects</h2>
         <ul>
+            <li><a href="https://loraatx.github.io/_starter/">Starter Template</a></li>
             <li><a href="https://loraatx.github.io/austin-3d/">Austin 3D Map</a></li>
             <li><a href="https://loraatx.github.io/kml-viewer/">KML Viewer</a></li>
         </ul>
-    </section>
-
-    <section class="projects-section" id="projects">
-        <h2>Projects</h2>
-        <div class="project-grid" id="projects-grid"></div>
     </section>
 
     <section class="content-section" id="contact">
@@ -289,6 +281,7 @@
             <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
         </div>
         <p>For inquiries, please reach out to <a href="mailto:info@loraatx.city">info@loraatx.city</a>.</p>
+    </section>
     <section id="kickstarter" class="section">
         <h2>Kickstarter</h2>
         <p>Support our campaign to build a city-wide IoT network for Austin.</p>
@@ -305,15 +298,6 @@
     <footer>
         <p>&copy; 2025 LoRaATX. All rights reserved. Contact <a href="mailto:info@loraatx.city" style="color: inherit; text-decoration: underline;">info@loraatx.city</a></p>
     </footer>
-    <script src="assets/js/projects.js"></script>
-<!-- Projects -->
-<section id="projects">
-  <h2>Projects</h2>
-  <ul>
-    <li><a href="https://loraatx.github.io/austin-3d/">Austin 3D Map</a></li>
-    <li><a href="https://loraatx.github.io/kml-viewer/">KML Viewer</a></li>
-  </ul>
-</section>
     <script>
         const form = document.getElementById('contactForm');
         form.addEventListener('submit', function (e) {

--- a/projects/apps/index.html
+++ b/projects/apps/index.html
@@ -7,9 +7,9 @@
 <body>
   <h1>Apps</h1>
   <ul>
-    <li><a href="https://loraatx.github.io/_starter/">_starter</a></li>
-    <li><a href="https://loraatx.github.io/austin-3d/">austin-3d</a></li>
-    <li><a href="https://loraatx.github.io/kml-viewer/">kml-viewer</a></li>
+    <li><a href="https://loraatx.github.io/_starter/">Starter Template</a></li>
+    <li><a href="https://loraatx.github.io/austin-3d/">Austin 3D Map</a></li>
+    <li><a href="https://loraatx.github.io/kml-viewer/">KML Viewer</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Consolidate Projects section in root index and link to standalone app repositories
- Update apps listing to point to external GitHub Pages URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b289d2dd1c832ab6fa62ce6ff38d38