### PR TITLE
Simplify banner and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
       --gap:16px;
       --pad:clamp(14px, 3vw, 24px);
       --section-pad:clamp(32px, 5vw, 72px);
-      --sticky-h:56px;        /* nav height for offset calculations */
     }
 
     /* ---- Base ---- */
@@ -43,67 +42,18 @@
 
     /* ---- Banner ---- */
     header.banner{
-      background:linear-gradient(180deg, #1a1a21, #101015);
+      background:#141418;
       border-bottom:1px solid #22232a;
+      padding:var(--pad) 0;
     }
-    .hero{
-      position:relative;
-      aspect-ratio:16/9; /* standard banner area; swap with real image/video later */
-      width:100%;
-      background:
-        radial-gradient(60% 60% at 60% 40%, rgba(225,122,0,.18) 0%, rgba(225,122,0,0) 60%),
-        radial-gradient(50% 50% at 20% 20%, rgba(43,144,217,.18) 0%, rgba(43,144,217,0) 60%),
-        url("assets/banner-placeholder.jpg") center/cover no-repeat;
-      border-radius:0 0 var(--radius) var(--radius);
-      box-shadow:var(--shadow);
-      overflow:hidden;
-    }
-    .hero .hero-text{
-      position:absolute; inset:auto 0 0 0;
-      padding: clamp(16px, 4vw, 28px);
-      background:linear-gradient(180deg, rgba(16,16,21,0) 0%, rgba(16,16,21,.85) 60%, rgba(16,16,21,.95) 100%);
-    }
-    .kicker{
-      display:inline-block; font-size:.8rem; letter-spacing:.08em; text-transform:uppercase; color:var(--muted);
-    }
-    h1{margin:.25rem 0 .5rem; font-size: clamp(1.4rem, 4vw, 2.2rem)}
-    .sub{color:var(--muted); max-width:65ch}
-
-    /* ---- Nav (sticky, under banner) ---- */
-    nav#site-nav{
-      position:sticky; top:0; z-index:50;
-      background:rgba(14,14,17,.8);
-      backdrop-filter: blur(10px);
-      border-bottom:1px solid #22232a;
-    }
-    .nav-inner{display:flex; align-items:center; gap:8px; height:var(--sticky-h)}
-    .brand{font-weight:700; letter-spacing:.02em}
-    .spacer{flex:1}
-    .menu-btn{
-      display:inline-flex; align-items:center; justify-content:center;
-      width:40px; height:40px; border-radius:10px; border:1px solid #2a2b33; background:#17171d; color:var(--text);
-    }
-    ul.menu{
-      list-style:none; margin:0; padding:0; display:none; gap:6px;
-    }
-    ul.menu a{
-      display:block; padding:.5rem .75rem; border-radius:10px; border:1px solid transparent;
-    }
-    ul.menu a:hover{border-color:#2a2b33; background:#181821}
-    /* show horizontal menu on >= 720px */
-    @media (min-width:720px){
-      .menu-btn{display:none}
-      ul.menu{display:flex}
-    }
-
-    /* ---- Mobile drawer ---- */
-    .drawer{display:none; border-bottom:1px solid #22232a; background:#101015}
-    .drawer a{display:block; padding:.85rem var(--pad); border-top:1px solid #1a1b22}
+    header.banner h1{margin:0; font-size: clamp(1.4rem, 4vw, 2.2rem)}
+    header.banner nav{margin-top:8px}
+    header.banner nav a{margin-right:1rem; color:var(--accent-2)}
+    header.banner nav a:last-child{margin-right:0}
 
     /* ---- Sections ---- */
     section{
       padding:var(--section-pad) 0;
-      scroll-margin-top: calc(var(--sticky-h) + 10px);
       border-bottom:1px solid #1a1b22;
     }
     section:last-of-type{border-bottom:none}
@@ -149,47 +99,19 @@
 <body>
   <a class="skip-to" href="#about" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
 
-  <!-- Header / Banner -->
+  <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <div class="hero" role="img" aria-label="Austin skyline banner image placeholder">
-        <div class="hero-text">
-          <span class="kicker">Austin • Maps • Planning</span>
-          <h1>LoRaATX: Maps, Apps, and Urban Planning Experiments</h1>
-          <p class="sub">This site is a <strong>container</strong>. Code, apps, and assets live in separate repositories. Here you’ll find links, embeds, and project status.</p>
-          <p>
-            <a class="btn btn-accent" href="#apps">Explore Apps</a>
-            <a class="btn" href="#projects">View Projects</a>
-          </p>
-        </div>
-      </div>
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="#about">About</a>
+        <a href="#apps">Apps</a>
+        <a href="#projects">Projects</a>
+        <a href="#videos">Videos</a>
+        <a href="#kickstarter">Kickstarter</a>
+      </nav>
     </div>
   </header>
-
-  <!-- Sticky Nav under banner -->
-  <nav id="site-nav" aria-label="Primary">
-    <div class="wrap nav-inner">
-      <div class="brand">loraatx.city</div>
-      <div class="spacer"></div>
-      <button id="menuButton" class="menu-btn" aria-expanded="false" aria-controls="mobileMenu" aria-label="Open menu">
-        ☰
-      </button>
-      <ul class="menu" id="desktopMenu">
-        <li><a href="#about">About</a></li>
-        <li><a href="#apps">Apps</a></li>
-        <li><a href="#projects">Projects</a></li>
-        <li><a href="#videos">Videos</a></li>
-        <li><a href="#kickstarter">Kickstarter</a></li>
-      </ul>
-    </div>
-    <div id="mobileMenu" class="drawer" hidden>
-      <a href="#about">About</a>
-      <a href="#apps">Apps</a>
-      <a href="#projects">Projects</a>
-      <a href="#videos">Videos</a>
-      <a href="#kickstarter">Kickstarter</a>
-    </div>
-  </nav>
 
   <main id="content">
     <!-- About -->
@@ -337,53 +259,7 @@
   </noscript>
 
   <script>
-    // ---- Mobile menu toggle ----
-    (function(){
-      const btn = document.getElementById('menuButton');
-      const drawer = document.getElementById('mobileMenu');
-      const desktopMenu = document.getElementById('desktopMenu');
-
-      function closeDrawer(){ drawer.hidden = true; btn.setAttribute('aria-expanded','false'); }
-      function openDrawer(){ drawer.hidden = false; btn.setAttribute('aria-expanded','true'); }
-
-      btn.addEventListener('click', () => {
-        if (drawer.hidden) openDrawer(); else closeDrawer();
-      });
-
-      drawer.addEventListener('click', (e) => {
-        if (e.target.tagName === 'A') closeDrawer();
-      });
-
-      // Close drawer if switching to desktop
-      const mq = window.matchMedia('(min-width:720px)');
-      mq.addEventListener('change', () => { if (mq.matches) closeDrawer(); });
-
-      // Active link highlight on scroll (simple, cheap)
-      const sections = ['about','apps','projects','videos','kickstarter']
-        .map(id => document.getElementById(id))
-        .filter(Boolean);
-
-      const links = [...(desktopMenu?.querySelectorAll('a') || []), ...(drawer?.querySelectorAll('a') || [])];
-
-      function setActive(id){
-        links.forEach(a => {
-          const on = a.getAttribute('href') === '#' + id;
-          a.style.borderColor = on ? '#2a2b33' : 'transparent';
-          a.style.background = on ? '#181821' : 'transparent';
-        });
-      }
-
-      const obs = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) setActive(entry.target.id);
-        });
-      }, { rootMargin: '-56px 0px -70% 0px', threshold: 0.1 });
-
-      sections.forEach(sec => obs.observe(sec));
-
-      // Footer year
-      document.getElementById('year').textContent = new Date().getFullYear();
-    })();
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace hero and sticky nav with simple banner and navigation links
- trim unused scripts and styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c0710eb4832a98feaa99ed4ea160