### PR TITLE
Simplify styles and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,85 +7,31 @@
   <meta name="description" content="Austin-focused maps, apps, and planning projects. This site is a container linking to standalone repos and embeddable apps." />
   <link rel="icon" href="favicon.ico" />
   <style>
-    /* ---- Root tokens: quick theming ---- */
-    :root{
-      --bg:#0e0e11;
-      --text:#e9e9f0;
-      --muted:#b7b7c2;
-      --accent-2:#2b90d9;     /* alt accent for links/buttons */
-      --maxw:1100px;
-      --gap:16px;
-      --pad:clamp(14px, 3vw, 24px);
-      --section-pad:clamp(32px, 5vw, 72px);
-    }
-
-    /* ---- Base ---- */
-    *{box-sizing:border-box}
-    html{scroll-behavior:smooth}
     body{
       margin:0;
-      background:var(--bg);
-      color:var(--text);
-      font: 16px/1.6 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-      -webkit-font-smoothing: antialiased;
-      text-rendering: optimizeLegibility;
+      padding:0;
+      background:#0e0e11;
+      color:#e9e9f0;
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
     }
-    a{color:var(--accent-2); text-decoration:none}
-    a:hover{text-decoration:underline}
-    img{max-width:100%; display:block}
-
-    .wrap{max-width:var(--maxw); margin-inline:auto; padding-inline:var(--pad)}
-
-    /* ---- Banner ---- */
-    header.banner{
-      background:#141418;
-      border-bottom:1px solid #22232a;
-      padding:var(--pad) 0;
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
     }
-    header.banner h1{margin:0; font-size: clamp(1.4rem, 4vw, 2.2rem)}
-    header.banner nav{margin-top:8px}
-    header.banner nav a{margin-right:1rem; color:var(--accent-2)}
-    header.banner nav a:last-child{margin-right:0}
-
-    /* ---- Sections ---- */
-    section{
-      padding:var(--section-pad) 0;
-      border-bottom:1px solid #1a1b22;
-    }
-    section:last-of-type{border-bottom:none}
-    h2{font-size: clamp(1.2rem, 3.5vw, 1.8rem); margin:0 0 .5rem}
-    p{margin:.5rem 0 1rem}
-
-    /* ---- Sections Layout ---- */
-    .section-grid{
-      display:flex;
-      flex-direction:column;
-      gap:var(--gap);
-      align-items:stretch;
-    }
-    .section-grid .media,
-    .section-grid .links{flex:1}
-    @media (min-width:720px){
-      .section-grid{flex-direction:row; align-items:center}
-      section:nth-of-type(even) .section-grid{flex-direction:row-reverse}
-    }
-    .links ol{margin:0; padding-left:1.2rem}
-    .links li{margin-bottom:.5rem}
-    .muted{color:var(--muted)}
-
-    /* ---- Utility Grid ---- */
-    .grid{
-      display:grid;
-      gap:var(--gap);
-      grid-template-columns:1fr;
-    }
-    @media (min-width:720px){
-      .grid.cols-2{grid-template-columns:1fr 1fr}
-      .grid.cols-3{grid-template-columns:repeat(3,1fr)}
-    }
-
-    /* ---- Footer ---- */
-    footer{padding:40px 0; color:var(--muted); font-size:.95rem}
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace complex theme variables with straightforward body, heading, and link styles
- add a simple `.section-grid` for responsive two-column sections
- trim extraneous rules for a minimal, clear stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c373ad80832aac3cf621511ef7fb