### PR TITLE
Add alternating layout and standalone section pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LoRaATX — About</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="About LoRaATX and how to reach us." />
+  <link rel="icon" href="favicon.ico" />
+  <style>
+    :root{
+      --bg:#0e0e11;
+      --text:#e9e9f0;
+    }
+    body{
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--text);
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    }
+    .light{
+      --bg:#ffffff;
+      --text:#0e0e11;
+    }
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
+    }
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
+  </style>
+</head>
+<body>
+  <a class="skip-to" href="#about" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+
+  <!-- Simple Banner -->
+  <header class="banner">
+    <div class="wrap">
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#apps">Apps</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#videos">Videos</a>
+        <a href="index.html#kickstarter">Kickstarter</a>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section id="about">
+      <div class="wrap">
+        <div class="section-grid">
+          <div class="media">
+            <img src="https://via.placeholder.com/640x360?text=About" alt="About LoRaATX placeholder image">
+          </div>
+          <div class="links">
+            <h2>About</h2>
+            <ol>
+              <li><a href="https://github.com/loraatx" target="_blank" rel="noopener">GitHub Org</a> — project source and issues.</li>
+              <li><a href="mailto:you@loraatx.city">Email</a> — reach out for collaboration.</li>
+              <li><a href="index.html#apps">Featured Apps</a> — explore interactive tools.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">
+      <div class="grid cols-2">
+        <div>
+          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
+        </div>
+        <div>
+          <div class="muted">Attribution &amp; Licenses: Placeholder for map/data credits and repo licenses.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="wrap" style="color:#ffbd2f; padding:12px 0">This site works better with JavaScript enabled.</div>
+  </noscript>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const root=document.documentElement;
+    const toggle=document.getElementById('theme-toggle');
+    if(localStorage.getItem('theme')==='light'){
+      root.classList.add('light');
+    }
+    toggle.addEventListener('click',()=>{
+      root.classList.toggle('light');
+      localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
+    });
+  </script>
+</body>
+</html>

--- a/apps.html
+++ b/apps.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LoRaATX — Apps</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Interactive apps built by LoRaATX." />
+  <link rel="icon" href="favicon.ico" />
+  <style>
+    :root{
+      --bg:#0e0e11;
+      --text:#e9e9f0;
+    }
+    body{
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--text);
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    }
+    .light{
+      --bg:#ffffff;
+      --text:#0e0e11;
+    }
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
+    }
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
+  </style>
+</head>
+<body>
+  <a class="skip-to" href="#apps" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+
+  <!-- Simple Banner -->
+  <header class="banner">
+    <div class="wrap">
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#apps">Apps</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#videos">Videos</a>
+        <a href="index.html#kickstarter">Kickstarter</a>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section id="apps">
+      <div class="wrap">
+        <div class="section-grid reverse">
+          <div class="media">
+            <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
+          </div>
+          <div class="links">
+            <h2>Apps</h2>
+            <ol>
+              <li><a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a> — interactive MapLibre view with OpenFreeMap styles.</li>
+              <li><a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a> — city-level zoning layers with filters.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">
+      <div class="grid cols-2">
+        <div>
+          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
+        </div>
+        <div>
+          <div class="muted">Attribution &amp; Licenses: Placeholder for map/data credits and repo licenses.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="wrap" style="color:#ffbd2f; padding:12px 0">This site works better with JavaScript enabled.</div>
+  </noscript>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const root=document.documentElement;
+    const toggle=document.getElementById('theme-toggle');
+    if(localStorage.getItem('theme')==='light'){
+      root.classList.add('light');
+    }
+    toggle.addEventListener('click',()=>{
+      root.classList.toggle('light');
+      localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     .section-grid .media,.section-grid .links{flex:1;}
     @media(min-width:720px){
       .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
     }
     footer{padding:40px 0;}
     img{max-width:100%;display:block;}
@@ -75,6 +76,7 @@
               <li><a href="https://github.com/loraatx" target="_blank" rel="noopener">GitHub Org</a> — project source and issues.</li>
               <li><a href="mailto:you@loraatx.city">Email</a> — reach out for collaboration.</li>
               <li><a href="#apps">Featured Apps</a> — explore interactive tools.</li>
+              <li><a href="about.html">About page</a> — section-only view.</li>
             </ol>
           </div>
         </div>
@@ -84,7 +86,7 @@
     <!-- Apps -->
     <section id="apps">
       <div class="wrap">
-        <div class="section-grid">
+        <div class="section-grid reverse">
           <div class="media">
             <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
@@ -93,6 +95,7 @@
             <ol>
               <li><a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a> — interactive MapLibre view with OpenFreeMap styles.</li>
               <li><a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a> — city-level zoning layers with filters.</li>
+              <li><a href="apps.html">Apps page</a> — section-only view.</li>
             </ol>
           </div>
         </div>
@@ -112,6 +115,7 @@
               <li><a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a> — docs, network maps, and demo apps.</li>
               <li><a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin Experiments</a> — tokenized civic incentives.</li>
               <li><a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a> — curated Austin planning docs with metadata.</li>
+              <li><a href="projects.html">Projects page</a> — section-only view.</li>
             </ol>
           </div>
         </div>
@@ -121,7 +125,7 @@
     <!-- Videos -->
     <section id="videos">
       <div class="wrap">
-        <div class="section-grid">
+        <div class="section-grid reverse">
           <div class="media">
             <iframe
               src="https://www.youtube.com/embed?listType=playlist&list=PL_PLACEHOLDER"
@@ -136,6 +140,7 @@
               <li><a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a> — long-form talks and walkthroughs.</li>
               <li><a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a> — quick clips and updates.</li>
               <li><a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a> — short-form experiments.</li>
+              <li><a href="videos.html">Videos page</a> — section-only view.</li>
             </ol>
           </div>
         </div>
@@ -154,6 +159,7 @@
             <ol>
               <li><a href="https://www.kickstarter.com/projects/YOURPROJECT" target="_blank" rel="noopener">Back the Project</a> — support development in Austin.</li>
               <li><a href="mailto:you@loraatx.city">Contact</a> — ask about rewards or partnerships.</li>
+              <li><a href="kickstarter.html">Kickstarter page</a> — section-only view.</li>
             </ol>
           </div>
         </div>

--- a/kickstarter.html
+++ b/kickstarter.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LoRaATX — Kickstarter</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Support the LoRaATX Kickstarter campaign." />
+  <link rel="icon" href="favicon.ico" />
+  <style>
+    :root{
+      --bg:#0e0e11;
+      --text:#e9e9f0;
+    }
+    body{
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--text);
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    }
+    .light{
+      --bg:#ffffff;
+      --text:#0e0e11;
+    }
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
+    }
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
+  </style>
+</head>
+<body>
+  <a class="skip-to" href="#kickstarter" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+
+  <!-- Simple Banner -->
+  <header class="banner">
+    <div class="wrap">
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#apps">Apps</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#videos">Videos</a>
+        <a href="index.html#kickstarter">Kickstarter</a>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section id="kickstarter">
+      <div class="wrap">
+        <div class="section-grid">
+          <div class="media">
+            <iframe src="https://www.kickstarter.com/projects/YOURPROJECT/widget/card.html" title="Kickstarter embed" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
+          </div>
+          <div class="links">
+            <h2>Kickstarter</h2>
+            <ol>
+              <li><a href="https://www.kickstarter.com/projects/YOURPROJECT" target="_blank" rel="noopener">Back the Project</a> — support development in Austin.</li>
+              <li><a href="mailto:you@loraatx.city">Contact</a> — ask about rewards or partnerships.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">
+      <div class="grid cols-2">
+        <div>
+          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
+        </div>
+        <div>
+          <div class="muted">Attribution &amp; Licenses: Placeholder for map/data credits and repo licenses.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="wrap" style="color:#ffbd2f; padding:12px 0">This site works better with JavaScript enabled.</div>
+  </noscript>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const root=document.documentElement;
+    const toggle=document.getElementById('theme-toggle');
+    if(localStorage.getItem('theme')==='light'){
+      root.classList.add('light');
+    }
+    toggle.addEventListener('click',()=>{
+      root.classList.toggle('light');
+      localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
+    });
+  </script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LoRaATX — Projects</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Planning and civic projects from LoRaATX." />
+  <link rel="icon" href="favicon.ico" />
+  <style>
+    :root{
+      --bg:#0e0e11;
+      --text:#e9e9f0;
+    }
+    body{
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--text);
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    }
+    .light{
+      --bg:#ffffff;
+      --text:#0e0e11;
+    }
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
+    }
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
+  </style>
+</head>
+<body>
+  <a class="skip-to" href="#projects" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+
+  <!-- Simple Banner -->
+  <header class="banner">
+    <div class="wrap">
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#apps">Apps</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#videos">Videos</a>
+        <a href="index.html#kickstarter">Kickstarter</a>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section id="projects">
+      <div class="wrap">
+        <div class="section-grid">
+          <div class="media">
+            <img src="https://via.placeholder.com/640x360?text=Projects" alt="Projects placeholder image">
+          </div>
+          <div class="links">
+            <h2>Projects</h2>
+            <ol>
+              <li><a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a> — docs, network maps, and demo apps.</li>
+              <li><a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin Experiments</a> — tokenized civic incentives.</li>
+              <li><a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a> — curated Austin planning docs with metadata.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">
+      <div class="grid cols-2">
+        <div>
+          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
+        </div>
+        <div>
+          <div class="muted">Attribution &amp; Licenses: Placeholder for map/data credits and repo licenses.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="wrap" style="color:#ffbd2f; padding:12px 0">This site works better with JavaScript enabled.</div>
+  </noscript>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const root=document.documentElement;
+    const toggle=document.getElementById('theme-toggle');
+    if(localStorage.getItem('theme')==='light'){
+      root.classList.add('light');
+    }
+    toggle.addEventListener('click',()=>{
+      root.classList.toggle('light');
+      localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
+    });
+  </script>
+</body>
+</html>

--- a/videos.html
+++ b/videos.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LoRaATX — Videos</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Video content from LoRaATX." />
+  <link rel="icon" href="favicon.ico" />
+  <style>
+    :root{
+      --bg:#0e0e11;
+      --text:#e9e9f0;
+    }
+    body{
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--text);
+      font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+    }
+    .light{
+      --bg:#ffffff;
+      --text:#0e0e11;
+    }
+    h1,h2{margin:0 0 .5rem;}
+    a{color:#2b90d9;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+    ol{margin:0;padding-left:1.2rem;}
+    li{margin-bottom:.5rem;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
+    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner nav a{margin-right:1rem;}
+    header.banner nav a:last-child{margin-right:0;}
+    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    section{padding:32px 0;border-bottom:1px solid #1a1b22;}
+    section:last-of-type{border-bottom:none;}
+    .section-grid{display:flex;flex-direction:column;gap:16px;}
+    .section-grid .media,.section-grid .links{flex:1;}
+    @media(min-width:720px){
+      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid.reverse{flex-direction:row-reverse;}
+    }
+    footer{padding:40px 0;}
+    img{max-width:100%;display:block;}
+  </style>
+</head>
+<body>
+  <a class="skip-to" href="#videos" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+
+  <!-- Simple Banner -->
+  <header class="banner">
+    <div class="wrap">
+      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <nav aria-label="Primary">
+        <a href="index.html#about">About</a>
+        <a href="index.html#apps">Apps</a>
+        <a href="index.html#projects">Projects</a>
+        <a href="index.html#videos">Videos</a>
+        <a href="index.html#kickstarter">Kickstarter</a>
+        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="content">
+    <section id="videos">
+      <div class="wrap">
+        <div class="section-grid reverse">
+          <div class="media">
+            <iframe
+              src="https://www.youtube.com/embed?listType=playlist&list=PL_PLACEHOLDER"
+              title="YouTube playlist"
+              style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen></iframe>
+          </div>
+          <div class="links">
+            <h2>Videos</h2>
+            <ol>
+              <li><a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a> — long-form talks and walkthroughs.</li>
+              <li><a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a> — quick clips and updates.</li>
+              <li><a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a> — short-form experiments.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap">
+      <div class="grid cols-2">
+        <div>
+          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
+        </div>
+        <div>
+          <div class="muted">Attribution &amp; Licenses: Placeholder for map/data credits and repo licenses.</div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="wrap" style="color:#ffbd2f; padding:12px 0">This site works better with JavaScript enabled.</div>
+  </noscript>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    const root=document.documentElement;
+    const toggle=document.getElementById('theme-toggle');
+    if(localStorage.getItem('theme')==='light'){
+      root.classList.add('light');
+    }
+    toggle.addEventListener('click',()=>{
+      root.classList.toggle('light');
+      localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- alternate media and link columns by introducing `.section-grid.reverse`
- link each home page section to a new dedicated page
- create standalone pages for About, Apps, Projects, Videos, and Kickstarter

## Testing
- `npx htmlhint *.html` *(fails: 403 Forbidden fetching htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c98c40c4832a967518717160ea44