### PR TITLE
Rebrand site to Austin Long Range with new header palette

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,14 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — About</title>
+  <title>Austin Long Range — About</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="About LoRaATX and how to reach us." />
+  <meta name="description" content="About Austin Long Range and how to reach us." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#apps">Apps</a>
@@ -67,7 +72,7 @@
       <div class="wrap">
         <div class="section-grid">
           <div class="media">
-            <img src="https://via.placeholder.com/640x360?text=About" alt="About LoRaATX placeholder image">
+            <img src="https://via.placeholder.com/640x360?text=About" alt="About Austin Long Range placeholder image">
           </div>
           <div class="links">
             <h2>About</h2>
@@ -86,7 +91,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>

--- a/apps.html
+++ b/apps.html
@@ -2,14 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — Apps</title>
+  <title>Austin Long Range — Apps</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Interactive apps built by LoRaATX." />
+  <meta name="description" content="Interactive apps built by Austin Long Range." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#apps">Apps</a>
@@ -85,7 +90,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — Austin Maps & Apps</title>
+  <title>Austin Long Range</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Austin-focused maps, apps, and planning projects. This site is a container linking to standalone repos and embeddable apps." />
   <link rel="icon" href="favicon.ico" />
@@ -10,6 +10,11 @@
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="#about">About</a>
         <a href="#apps">Apps</a>
@@ -68,7 +73,7 @@
       <div class="wrap">
         <div class="section-grid">
           <div class="media">
-            <img src="https://via.placeholder.com/640x360?text=About" alt="About LoRaATX placeholder image">
+            <img src="https://via.placeholder.com/640x360?text=About" alt="About Austin Long Range placeholder image">
           </div>
           <div class="links">
             <h2>About</h2>
@@ -171,7 +176,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>

--- a/kickstarter.html
+++ b/kickstarter.html
@@ -2,14 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — Kickstarter</title>
+  <title>Austin Long Range — Kickstarter</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Support the LoRaATX Kickstarter campaign." />
+  <meta name="description" content="Support the Austin Long Range Kickstarter campaign." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#apps">Apps</a>
@@ -85,7 +90,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>

--- a/projects.html
+++ b/projects.html
@@ -2,14 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — Projects</title>
+  <title>Austin Long Range — Projects</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Planning and civic projects from LoRaATX." />
+  <meta name="description" content="Planning and civic projects from Austin Long Range." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#apps">Apps</a>
@@ -86,7 +91,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>

--- a/videos.html
+++ b/videos.html
@@ -2,14 +2,19 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>LoRaATX — Videos</title>
+  <title>Austin Long Range — Videos</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Video content from LoRaATX." />
+  <meta name="description" content="Video content from Austin Long Range." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
       --bg:#0e0e11;
       --text:#e9e9f0;
+      --sand:#d4aa7d;
+      --brown:#8f5a30;
+      --dark-brown:#5b341a;
+      --blue:#2c7be5;
+      --light-blue:#63b3ff;
     }
     body{
       margin:0;
@@ -23,12 +28,12 @@
       --text:#0e0e11;
     }
     h1,h2{margin:0 0 .5rem;}
-    a{color:#2b90d9;text-decoration:none;}
-    a:hover{text-decoration:underline;}
+    a{color:var(--blue);text-decoration:none;}
+    a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:#141418;border-bottom:1px solid #22232a;padding:16px 0;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
     header.banner nav a:last-child{margin-right:0;}
     header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
@@ -50,7 +55,7 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>LoRaATX — Austin Maps &amp; Apps</h1>
+      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#apps">Apps</a>
@@ -91,7 +96,7 @@
     <div class="wrap">
       <div class="grid cols-2">
         <div>
-          <div class="muted">© <span id="year"></span> LoRaATX · Austin, Texas</div>
+          <div class="muted">© <span id="year"></span> Austin Long Range · Austin, Texas</div>
           <div class="muted">Contact: <a href="mailto:you@loraatx.city">you@loraatx.city</a></div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- rename site to Austin Long Range across pages
- apply tan/brown/blue palette to header and links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d94bf238832abd811d599e37c3fc