### PR TITLE
Add services section with paragraph summaries

### DIFF
--- a/about.html
+++ b/about.html
@@ -58,6 +58,7 @@
       <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
+        <a href="index.html#services">Services</a>
         <a href="index.html#apps">Apps</a>
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
+    .links p{margin:0;padding:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
@@ -58,6 +59,7 @@
       <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="#about">About</a>
+        <a href="#services">Services</a>
         <a href="#apps">Apps</a>
         <a href="#projects">Projects</a>
         <a href="#videos">Videos</a>
@@ -77,12 +79,22 @@
           </div>
           <div class="links">
             <h2>About</h2>
-            <ol>
-              <li><a href="https://github.com/loraatx" target="_blank" rel="noopener">GitHub Org</a> — project source and issues.</li>
-              <li><a href="mailto:you@loraatx.city">Email</a> — reach out for collaboration.</li>
-              <li><a href="#apps">Featured Apps</a> — explore interactive tools.</li>
-              <li><a href="about.html">About page</a> — section-only view.</li>
-            </ol>
+            <p><a href="about.html">About</a>: Explore our <a href="https://github.com/loraatx" target="_blank" rel="noopener">GitHub Org</a>, get in touch via <a href="mailto:you@loraatx.city">email</a>, browse <a href="#apps">featured apps</a>, or dive deeper on the <a href="about.html">About page</a>.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Services -->
+    <section id="services">
+      <div class="wrap">
+        <div class="section-grid reverse">
+          <div class="media">
+            <img src="https://via.placeholder.com/640x360?text=Services" alt="Services placeholder image">
+          </div>
+          <div class="links">
+            <h2>Services</h2>
+            <p><a href="services.html">Services</a>: Learn about consulting and mapping offerings, request custom tools via <a href="mailto:you@loraatx.city">email</a>, or review our <a href="#projects">projects</a> for past work.</p>
           </div>
         </div>
       </div>
@@ -91,17 +103,13 @@
     <!-- Apps -->
     <section id="apps">
       <div class="wrap">
-        <div class="section-grid reverse">
+        <div class="section-grid">
           <div class="media">
             <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
           <div class="links">
             <h2>Apps</h2>
-            <ol>
-              <li><a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a> — interactive MapLibre view with OpenFreeMap styles.</li>
-              <li><a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a> — city-level zoning layers with filters.</li>
-              <li><a href="apps.html">Apps page</a> — section-only view.</li>
-            </ol>
+            <p><a href="apps.html">Apps</a>: Try the <a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a>, experiment with the <a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a>, or see more on the <a href="apps.html">Apps page</a>.</p>
           </div>
         </div>
       </div>
@@ -116,12 +124,7 @@
           </div>
           <div class="links">
             <h2>Projects</h2>
-            <ol>
-              <li><a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a> — docs, network maps, and demo apps.</li>
-              <li><a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin Experiments</a> — tokenized civic incentives.</li>
-              <li><a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a> — curated Austin planning docs with metadata.</li>
-              <li><a href="projects.html">Projects page</a> — section-only view.</li>
-            </ol>
+            <p><a href="projects.html">Projects</a>: Explore <a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a>, experiment with <a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin initiatives</a>, browse the <a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a>, or visit the <a href="projects.html">Projects page</a> for more.</p>
           </div>
         </div>
       </div>
@@ -141,12 +144,7 @@
           </div>
           <div class="links">
             <h2>Videos</h2>
-            <ol>
-              <li><a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a> — long-form talks and walkthroughs.</li>
-              <li><a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a> — quick clips and updates.</li>
-              <li><a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a> — short-form experiments.</li>
-              <li><a href="videos.html">Videos page</a> — section-only view.</li>
-            </ol>
+            <p><a href="videos.html">Videos</a>: Watch our <a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a>, check out <a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a>, see experiments on <a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a>, or view all on the <a href="videos.html">Videos page</a>.</p>
           </div>
         </div>
       </div>
@@ -161,11 +159,7 @@
           </div>
           <div class="links">
             <h2>Kickstarter</h2>
-            <ol>
-              <li><a href="https://www.kickstarter.com/projects/YOURPROJECT" target="_blank" rel="noopener">Back the Project</a> — support development in Austin.</li>
-              <li><a href="mailto:you@loraatx.city">Contact</a> — ask about rewards or partnerships.</li>
-              <li><a href="kickstarter.html">Kickstarter page</a> — section-only view.</li>
-            </ol>
+            <p><a href="kickstarter.html">Kickstarter</a>: <a href="https://www.kickstarter.com/projects/YOURPROJECT" target="_blank" rel="noopener">Back the project</a>, reach out via <a href="mailto:you@loraatx.city">email</a> for partnerships, or see details on the <a href="kickstarter.html">Kickstarter page</a>.</p>
           </div>
         </div>
       </div>

--- a/kickstarter.html
+++ b/kickstarter.html
@@ -58,6 +58,7 @@
       <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
+        <a href="index.html#services">Services</a>
         <a href="index.html#apps">Apps</a>
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>

--- a/projects.html
+++ b/projects.html
@@ -58,6 +58,7 @@
       <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
+        <a href="index.html#services">Services</a>
         <a href="index.html#apps">Apps</a>
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>

--- a/services.html
+++ b/services.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Austin Long Range — Apps</title>
+  <title>Austin Long Range — Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Interactive apps built by Austin Long Range." />
+  <meta name="description" content="Consulting and services offered by Austin Long Range." />
   <link rel="icon" href="favicon.ico" />
   <style>
     :root{
@@ -30,8 +30,7 @@
     h1,h2{margin:0 0 .5rem;}
     a{color:var(--blue);text-decoration:none;}
     a:hover{color:var(--light-blue);text-decoration:underline;}
-    ol{margin:0;padding-left:1.2rem;}
-    li{margin-bottom:.5rem;}
+    .links p{margin:0;padding:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
@@ -50,7 +49,7 @@
   </style>
 </head>
 <body>
-  <a class="skip-to" href="#apps" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
+  <a class="skip-to" href="#services" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Skip to content</a>
 
   <!-- Simple Banner -->
   <header class="banner">
@@ -69,18 +68,15 @@
   </header>
 
   <main id="content">
-    <section id="apps">
+    <section id="services">
       <div class="wrap">
-        <div class="section-grid reverse">
+        <div class="section-grid">
           <div class="media">
-            <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
+            <img src="https://via.placeholder.com/640x360?text=Services" alt="Services placeholder image">
           </div>
           <div class="links">
-            <h2>Apps</h2>
-            <ol>
-              <li><a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a> — interactive MapLibre view with OpenFreeMap styles.</li>
-              <li><a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a> — city-level zoning layers with filters.</li>
-            </ol>
+            <h2>Services</h2>
+            <p><a href="services.html">Services</a>: Details about consulting and mapping services will go here. Contact us via <a href="mailto:you@loraatx.city">email</a> for more information.</p>
           </div>
         </div>
       </div>

--- a/videos.html
+++ b/videos.html
@@ -58,6 +58,7 @@
       <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
+        <a href="index.html#services">Services</a>
         <a href="index.html#apps">Apps</a>
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>


### PR DESCRIPTION
## Summary
- replace homepage link lists with padded descriptive paragraphs
- add a Services section and standalone services page, updating navigation links

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b565985270832a84b52b055f935a1e