### PR TITLE
style: adjust section paragraphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
     a:hover{color:var(--light-blue);text-decoration:underline;}
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
-    .links p{margin:0;padding:.5rem;}
+    .links p{margin:0;padding:1rem;}
+    .links p a:first-of-type{font-size:1.125em;font-family:Georgia,serif;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
     header.banner nav a{margin-right:1rem;}
@@ -43,7 +44,7 @@
     .section-grid{display:flex;flex-direction:column;gap:16px;}
     .section-grid .media,.section-grid .links{flex:1;}
     @media(min-width:720px){
-      .section-grid{flex-direction:row;align-items:center;}
+      .section-grid{flex-direction:row;align-items:flex-start;}
       .section-grid.reverse{flex-direction:row-reverse;}
     }
     footer{padding:40px 0;}
@@ -78,7 +79,6 @@
             <img src="https://loraatx.city/img/about-img.webp">
           </div>
           <div class="links">
-            <h2>About</h2>
             <p><a href="about.html">About</a>: Explore our <a href="https://github.com/loraatx" target="_blank" rel="noopener">GitHub Org</a>, get in touch via <a href="mailto:you@loraatx.city">email</a>, browse <a href="#apps">featured apps</a>, or dive deeper on the <a href="about.html">About page</a>.</p>
           </div>
         </div>
@@ -93,7 +93,6 @@
             <img src="https://via.placeholder.com/640x360?text=Services" alt="Services placeholder image">
           </div>
           <div class="links">
-            <h2>Services</h2>
             <p><a href="services.html">Services</a>: Learn about consulting and mapping offerings, request custom tools via <a href="mailto:you@loraatx.city">email</a>, or review our <a href="#projects">projects</a> for past work.</p>
           </div>
         </div>
@@ -108,7 +107,6 @@
             <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
           <div class="links">
-            <h2>Apps</h2>
             <p><a href="apps.html">Apps</a>: Try the <a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a>, experiment with the <a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a>, or see more on the <a href="apps.html">Apps page</a>.</p>
           </div>
         </div>
@@ -123,7 +121,6 @@
             <img src="https://via.placeholder.com/640x360?text=Projects" alt="Projects placeholder image">
           </div>
           <div class="links">
-            <h2>Projects</h2>
             <p><a href="projects.html">Projects</a>: Explore <a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a>, experiment with <a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin initiatives</a>, browse the <a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a>, or visit the <a href="projects.html">Projects page</a> for more.</p>
           </div>
         </div>
@@ -143,7 +140,6 @@
               allowfullscreen></iframe>
           </div>
           <div class="links">
-            <h2>Videos</h2>
             <p><a href="videos.html">Videos</a>: Watch our <a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a>, check out <a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a>, see experiments on <a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a>, or view all on the <a href="videos.html">Videos page</a>.</p>
           </div>
         </div>
@@ -158,7 +154,6 @@
             <iframe src="https://www.kickstarter.com/projects/YOURPROJECT/widget/card.html" title="Kickstarter embed" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
           <div class="links">
-            <h2>Kickstarter</h2>
             <p><a href="kickstarter.html">Kickstarter</a>: <a href="https://www.kickstarter.com/projects/YOURPROJECT" target="_blank" rel="noopener">Back the project</a>, reach out via <a href="mailto:you@loraatx.city">email</a> for partnerships, or see details on the <a href="kickstarter.html">Kickstarter page</a>.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove section headings and add additional padding around home page paragraphs
- align text blocks with top of images and style the first linked word in a larger serif font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b56ec8b678832a974a59cd12b021e8