### PR TITLE
Remove header title and enhance theme toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,9 +34,14 @@
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -55,7 +60,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -63,7 +67,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -112,8 +121,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/apps.html
+++ b/apps.html
@@ -34,9 +34,14 @@
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -55,7 +60,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -63,7 +67,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -111,8 +120,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/index.html
+++ b/index.html
@@ -36,9 +36,14 @@
     .links p a:first-of-type{font-size:1.125em;font-family:Georgia,serif;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -57,7 +62,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="#about">About</a>
         <a href="#services">Services</a>
@@ -65,7 +69,12 @@
         <a href="#projects">Projects</a>
         <a href="#videos">Videos</a>
         <a href="#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -185,8 +194,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/kickstarter.html
+++ b/kickstarter.html
@@ -34,9 +34,14 @@
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -55,7 +60,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -63,7 +67,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -111,8 +120,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/projects.html
+++ b/projects.html
@@ -34,9 +34,14 @@
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -55,7 +60,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -63,7 +67,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -112,8 +121,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/services.html
+++ b/services.html
@@ -33,9 +33,14 @@
     .links p{margin:0;padding:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -54,7 +59,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -62,7 +66,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -107,8 +116,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });

--- a/videos.html
+++ b/videos.html
@@ -34,9 +34,14 @@
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav a{margin-right:1rem;}
-    header.banner nav a:last-child{margin-right:0;}
-    header.banner nav button{background:none;border:0;color:inherit;cursor:pointer;margin-left:1rem;}
+    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;}
+    header.banner nav a{font-size:1.25rem;}
+    header.banner nav .theme-toggle{display:flex;align-items:center;}
+    header.banner nav .theme-toggle input{display:none;}
+    header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--blue);border-radius:12px;margin:0 .5rem;}
+    header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
+    header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
+    header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     section{padding:32px 0;border-bottom:1px solid #1a1b22;}
     section:last-of-type{border-bottom:none;}
     .section-grid{display:flex;flex-direction:column;gap:16px;}
@@ -55,7 +60,6 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <h1>Austin Long Range</h1>
       <nav aria-label="Primary">
         <a href="index.html#about">About</a>
         <a href="index.html#services">Services</a>
@@ -63,7 +67,12 @@
         <a href="index.html#projects">Projects</a>
         <a href="index.html#videos">Videos</a>
         <a href="index.html#kickstarter">Kickstarter</a>
-        <button id="theme-toggle" aria-label="Toggle theme">🌓</button>
+        <label class="theme-toggle" for="theme-toggle">
+          <span class="sun">☀️</span>
+          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+          <span class="slider"></span>
+          <span class="moon">🌙</span>
+        </label>
       </nav>
     </div>
   </header>
@@ -117,8 +126,9 @@
     const toggle=document.getElementById('theme-toggle');
     if(localStorage.getItem('theme')==='light'){
       root.classList.add('light');
+      toggle.checked=true;
     }
-    toggle.addEventListener('click',()=>{
+    toggle.addEventListener('change',()=>{
       root.classList.toggle('light');
       localStorage.setItem('theme',root.classList.contains('light')?'light':'dark');
     });


### PR DESCRIPTION
## Summary
- Drop redundant header title and enlarge navigation links for better prominence
- Replace simple theme button with sun/moon toggle switch and persist preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5737a2790832a88a43eef008af5f0