### PR TITLE
style: enlarge about text and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .links p{margin:0;padding:1rem;}
+    #about .links p{font-size:1.125em;}
     .links p a:first-of-type{font-size:1.125em;font-family:Georgia,serif;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
@@ -92,7 +93,7 @@
             <img src="https://loraatx.city/img/about-img.webp">
           </div>
           <div class="links">
-            <p>About Aust Long Range: Aust Long Range delivers bespoke, affordable map applications tailored to individual needs. Alongside these custom tools, the site provides access to related projects, datasets, and resources, creating a central hub for practical urban insight and collaboration.</p>
+            <p>About Aust Long Range:<br><br>Aust Long Range delivers bespoke, affordable map applications tailored to individual needs. Alongside these custom tools, the site provides access to related projects, datasets, and resources, creating a central hub for practical urban insight and collaboration.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Increase the About section's paragraph font size for better readability.
- Add a blank line after the "About Aust Long Range:" heading to separate it from the description.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d2b7bd5c832a85ee647b0baf6a3e