### PR TITLE
style: add filler text to site sections

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -88,11 +88,7 @@
             <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
           <div class="links">
-            <p>Maps &amp; Apps: Try the <a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a>, experiment with the <a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a>, or explore other tools below.</p>
-            <ol>
-              <li><a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a> — interactive MapLibre view with OpenFreeMap styles.</li>
-              <li><a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a> — city-level zoning layers with filters.</li>
-            </ol>
+            <p>Maps &amp; Apps:<br><br>Hands-on demos and tools that blend geography with interactivity. These prototypes serve as starting points for deeper exploration.</p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             <img src="https://via.placeholder.com/640x360?text=Services" alt="Services placeholder image">
           </div>
           <div class="links">
-            <p><a href="services.html">Services</a>: Learn about consulting and mapping offerings, request custom tools via <a href="mailto:you@loraatx.city">email</a>, or review our <a href="#projects">side projects</a> for past work.</p>
+            <p>Services:<br><br>Custom mapping support and consultation for civic projects. Let's chart out the possibilities together with tailored tools and insights.</p>
           </div>
         </div>
       </div>
@@ -120,7 +120,7 @@
             <iframe src="https://loraatx.github.io/austin-3d/" title="Austin 3D Map" style="width:100%; aspect-ratio:16/9; border:0" loading="lazy"></iframe>
           </div>
           <div class="links">
-            <p><a href="apps.html">Maps &amp; Apps</a>: Try the <a href="https://loraatx.github.io/austin-3d/" target="_blank" rel="noopener">Austin 3D Map</a>, experiment with the <a href="https://loraatx.github.io/zoning-explorer/" target="_blank" rel="noopener">Zoning Overlay Explorer</a>, or see more on the <a href="apps.html">Maps &amp; Apps page</a>.</p>
+            <p>Maps &amp; Apps:<br><br>Interactive experiments that showcase spatial data in fresh ways. Explore prototypes that turn complex layers into approachable visuals.</p>
           </div>
         </div>
       </div>
@@ -134,7 +134,7 @@
             <img src="https://via.placeholder.com/640x360?text=Projects" alt="Side Projects placeholder image">
           </div>
           <div class="links">
-            <p><a href="projects.html">Side Projects</a>: Explore <a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a>, experiment with <a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin initiatives</a>, browse the <a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a>, or visit the <a href="projects.html">Side Projects page</a> for more.</p>
+            <p>Side Projects:<br><br>A collection of small-scale explorations built to test ideas and inspire conversation around planning and technology.</p>
           </div>
         </div>
       </div>

--- a/projects.html
+++ b/projects.html
@@ -88,12 +88,7 @@
             <img src="https://via.placeholder.com/640x360?text=Projects" alt="Side Projects placeholder image">
           </div>
           <div class="links">
-            <p>Side Projects: Explore the efforts below for documentation, experiments, and resources.</p>
-            <ol>
-              <li><a href="https://github.com/loraatx/lorawan-austin" target="_blank" rel="noopener">LoRaWAN Austin</a> — docs, network maps, and demo apps.</li>
-              <li><a href="https://github.com/loraatx/citycoin-experiments" target="_blank" rel="noopener">CityCoin Experiments</a> — tokenized civic incentives.</li>
-              <li><a href="https://github.com/loraatx/austin-planning-library" target="_blank" rel="noopener">Planning Library</a> — curated Austin planning docs with metadata.</li>
-            </ol>
+            <p>Side Projects:<br><br>Snapshots of independent work, documenting ideas that grew from curiosity. Each experiment adds a piece to a larger civic puzzle.</p>
           </div>
         </div>
       </div>

--- a/services.html
+++ b/services.html
@@ -87,7 +87,7 @@
             <img src="https://via.placeholder.com/640x360?text=Services" alt="Services placeholder image">
           </div>
           <div class="links">
-            <p>Services: Learn about consulting and mapping offerings, request custom tools via <a href="mailto:you@loraatx.city">email</a>, or review <a href="projects.html">side projects</a> for past work.</p>
+            <p>Services:<br><br>From data analysis to map-driven storytelling, each engagement is crafted to fit unique goals. Reach out to discuss possibilities and build something useful together.</p>
           </div>
         </div>
       </div>

--- a/videos.html
+++ b/videos.html
@@ -93,12 +93,7 @@
               allowfullscreen></iframe>
           </div>
           <div class="links">
-            <p>Videos: Watch the playlist, shorts, or experiments below.</p>
-            <ol>
-              <li><a href="https://www.youtube.com/playlist?list=PL_PLACEHOLDER" target="_blank" rel="noopener">Urban Planning Deep Dives</a> — long-form talks and walkthroughs.</li>
-              <li><a href="https://www.youtube.com/@YOURCHANNEL/shorts" target="_blank" rel="noopener">YouTube Shorts</a> — quick clips and updates.</li>
-              <li><a href="https://www.tiktok.com/@YOURHANDLE" target="_blank" rel="noopener">TikTok</a> — short-form experiments.</li>
-            </ol>
+            <p>Videos:<br><br>Short and long-form clips that explore planning concepts, technical tutorials, and behind-the-scenes glimpses of ongoing efforts.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace link-heavy blurbs with simple filler text in Services, Maps & Apps, Side Projects, and Videos sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f8a023c0832a8a81139e2c00054b