### PR TITLE
Fix project section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
     <!-- Side Projects -->
     <section id="projects">
       <div class="wrap">
-        <div class="section-grid">
+        <div class="section-grid reverse">
           <div class="media">
             <img src="https://loraatx.city/img/sideprojects.webp" alt="Side Projects placeholder image">
           </div>


### PR DESCRIPTION
## Summary
- Flip the homepage Side Projects section so its image appears on the right, alternating with the previous section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6036784f8832a9e2c43f764f392df