### PR TITLE
feat: add site title and social icons

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -34,8 +34,10 @@
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
+    .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}
     header.banner nav .theme-toggle{display:flex;align-items:center;}
@@ -44,7 +46,11 @@
     header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
+    .social-icons{display:flex;align-items:center;gap:1rem;}
+    .social-icons a{color:var(--nav-blue);}
+    .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
+      .header-content{flex-direction:column;}
       header.banner nav{flex-direction:column;gap:.75rem;}
       header.banner nav a{font-size:1rem;}
     }
@@ -66,17 +72,47 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <nav aria-label="Primary">
-        <a href="index.html#services">Services</a>
-        <a href="index.html#apps">Maps &amp; Apps</a>
-        <a href="index.html#projects">Side Projects</a>
-        <label class="theme-toggle" for="theme-toggle">
-          <span class="moon">🌙</span>
-          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
-          <span class="slider"></span>
-          <span class="sun">☀️</span>
-        </label>
-      </nav>
+      <div class="header-content">
+        <div class="site-title"><a href="index.html">Austin Long Range</a></div>
+        <nav aria-label="Primary">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#apps">Maps &amp; Apps</a>
+          <a href="index.html#projects">Side Projects</a>
+          <label class="theme-toggle" for="theme-toggle">
+            <span class="moon">🌙</span>
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+            <span class="slider"></span>
+            <span class="sun">☀️</span>
+          </label>
+        </nav>
+        <div class="social-icons">
+          <a href="https://github.com/loraatx" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="11"/>
+              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
+              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
+              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
+              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="https://x.com/loraatx" aria-label="X">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="20"/>
+              <circle cx="15" cy="10" r="8"/>
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -37,8 +37,10 @@
     #about .links p{font-size:1.125em;}
     .links p a:first-of-type{font-size:1.125em;font-family:Georgia,serif;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
+    .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}
     header.banner nav .theme-toggle{display:flex;align-items:center;}
@@ -47,7 +49,11 @@
     header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
+    .social-icons{display:flex;align-items:center;gap:1rem;}
+    .social-icons a{color:var(--nav-blue);}
+    .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
+      .header-content{flex-direction:column;}
       header.banner nav{flex-direction:column;gap:.75rem;}
       header.banner nav a{font-size:1rem;}
     }
@@ -69,17 +75,47 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <nav aria-label="Primary">
-        <a href="#services">Services</a>
-        <a href="#apps">Maps &amp; Apps</a>
-        <a href="#projects">Side Projects</a>
-        <label class="theme-toggle" for="theme-toggle">
-          <span class="moon">🌙</span>
-          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
-          <span class="slider"></span>
-          <span class="sun">☀️</span>
-        </label>
-      </nav>
+      <div class="header-content">
+        <div class="site-title"><a href="index.html">Austin Long Range</a></div>
+        <nav aria-label="Primary">
+          <a href="#services">Services</a>
+          <a href="#apps">Maps &amp; Apps</a>
+          <a href="#projects">Side Projects</a>
+          <label class="theme-toggle" for="theme-toggle">
+            <span class="moon">🌙</span>
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+            <span class="slider"></span>
+            <span class="sun">☀️</span>
+          </label>
+        </nav>
+        <div class="social-icons">
+          <a href="https://github.com/loraatx" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="11"/>
+              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
+              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
+              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
+              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="https://x.com/loraatx" aria-label="X">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="20"/>
+              <circle cx="15" cy="10" r="8"/>
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 

--- a/projects.html
+++ b/projects.html
@@ -34,8 +34,10 @@
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
+    .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}
     header.banner nav .theme-toggle{display:flex;align-items:center;}
@@ -44,7 +46,11 @@
     header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
+    .social-icons{display:flex;align-items:center;gap:1rem;}
+    .social-icons a{color:var(--nav-blue);}
+    .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
+      .header-content{flex-direction:column;}
       header.banner nav{flex-direction:column;gap:.75rem;}
       header.banner nav a{font-size:1rem;}
     }
@@ -66,17 +72,47 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <nav aria-label="Primary">
-        <a href="index.html#services">Services</a>
-        <a href="index.html#apps">Maps &amp; Apps</a>
-        <a href="index.html#projects">Side Projects</a>
-        <label class="theme-toggle" for="theme-toggle">
-          <span class="moon">🌙</span>
-          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
-          <span class="slider"></span>
-          <span class="sun">☀️</span>
-        </label>
-      </nav>
+      <div class="header-content">
+        <div class="site-title"><a href="index.html">Austin Long Range</a></div>
+        <nav aria-label="Primary">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#apps">Maps &amp; Apps</a>
+          <a href="index.html#projects">Side Projects</a>
+          <label class="theme-toggle" for="theme-toggle">
+            <span class="moon">🌙</span>
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+            <span class="slider"></span>
+            <span class="sun">☀️</span>
+          </label>
+        </nav>
+        <div class="social-icons">
+          <a href="https://github.com/loraatx" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="11"/>
+              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
+              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
+              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
+              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="https://x.com/loraatx" aria-label="X">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="20"/>
+              <circle cx="15" cy="10" r="8"/>
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 

--- a/services.html
+++ b/services.html
@@ -33,8 +33,10 @@
     a:hover{color:var(--light-blue);text-decoration:underline;}
     .links p{margin:0;padding:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
+    .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}
     header.banner nav .theme-toggle{display:flex;align-items:center;}
@@ -43,7 +45,11 @@
     header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
+    .social-icons{display:flex;align-items:center;gap:1rem;}
+    .social-icons a{color:var(--nav-blue);}
+    .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
+      .header-content{flex-direction:column;}
       header.banner nav{flex-direction:column;gap:.75rem;}
       header.banner nav a{font-size:1rem;}
     }
@@ -65,17 +71,47 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <nav aria-label="Primary">
-        <a href="index.html#services">Services</a>
-        <a href="index.html#apps">Maps &amp; Apps</a>
-        <a href="index.html#projects">Side Projects</a>
-        <label class="theme-toggle" for="theme-toggle">
-          <span class="moon">🌙</span>
-          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
-          <span class="slider"></span>
-          <span class="sun">☀️</span>
-        </label>
-      </nav>
+      <div class="header-content">
+        <div class="site-title"><a href="index.html">Austin Long Range</a></div>
+        <nav aria-label="Primary">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#apps">Maps &amp; Apps</a>
+          <a href="index.html#projects">Side Projects</a>
+          <label class="theme-toggle" for="theme-toggle">
+            <span class="moon">🌙</span>
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+            <span class="slider"></span>
+            <span class="sun">☀️</span>
+          </label>
+        </nav>
+        <div class="social-icons">
+          <a href="https://github.com/loraatx" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="11"/>
+              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
+              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
+              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
+              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="https://x.com/loraatx" aria-label="X">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="20"/>
+              <circle cx="15" cy="10" r="8"/>
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 

--- a/videos.html
+++ b/videos.html
@@ -34,8 +34,10 @@
     ol{margin:0;padding-left:1.2rem;}
     li{margin-bottom:.5rem;}
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);text-align:center;}
-    header.banner nav{display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
+    header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
+    .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
+    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}
     header.banner nav .theme-toggle{display:flex;align-items:center;}
@@ -44,7 +46,11 @@
     header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
+    .social-icons{display:flex;align-items:center;gap:1rem;}
+    .social-icons a{color:var(--nav-blue);}
+    .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
+      .header-content{flex-direction:column;}
       header.banner nav{flex-direction:column;gap:.75rem;}
       header.banner nav a{font-size:1rem;}
     }
@@ -66,17 +72,47 @@
   <!-- Simple Banner -->
   <header class="banner">
     <div class="wrap">
-      <nav aria-label="Primary">
-        <a href="index.html#services">Services</a>
-        <a href="index.html#apps">Maps &amp; Apps</a>
-        <a href="index.html#projects">Side Projects</a>
-        <label class="theme-toggle" for="theme-toggle">
-          <span class="moon">🌙</span>
-          <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
-          <span class="slider"></span>
-          <span class="sun">☀️</span>
-        </label>
-      </nav>
+      <div class="header-content">
+        <div class="site-title"><a href="index.html">Austin Long Range</a></div>
+        <nav aria-label="Primary">
+          <a href="index.html#services">Services</a>
+          <a href="index.html#apps">Maps &amp; Apps</a>
+          <a href="index.html#projects">Side Projects</a>
+          <label class="theme-toggle" for="theme-toggle">
+            <span class="moon">🌙</span>
+            <input type="checkbox" id="theme-toggle" aria-label="Toggle theme">
+            <span class="slider"></span>
+            <span class="sun">☀️</span>
+          </label>
+        </nav>
+        <div class="social-icons">
+          <a href="https://github.com/loraatx" aria-label="GitHub">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="11"/>
+              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
+              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
+              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
+              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+            </svg>
+          </a>
+          <a href="https://x.com/loraatx" aria-label="X">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+            </svg>
+          </a>
+          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="3" y="2" width="4" height="20"/>
+              <circle cx="15" cy="10" r="8"/>
+            </svg>
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add "Austin Long Range" site title on header left
- add GitHub, YouTube, X, and Patreon icons on header right
- keep nav responsive and maintain icon row on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c10f442c832a92c922fdaa07b999