### PR TITLE
style: adjust header title font

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -36,7 +36,8 @@
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
     .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    .site-title a{font-size:2rem;font-weight:bold;font-family:Georgia,'Times New Roman',Times,serif;color:var(--brown);}
+    .site-title a:hover{color:var(--brown);text-decoration:none;}
     header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}

--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
     .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    .site-title a{font-size:2rem;font-weight:bold;font-family:Georgia,'Times New Roman',Times,serif;color:var(--brown);}
+    .site-title a:hover{color:var(--brown);text-decoration:none;}
     header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}

--- a/projects.html
+++ b/projects.html
@@ -36,7 +36,8 @@
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
     .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    .site-title a{font-size:2rem;font-weight:bold;font-family:Georgia,'Times New Roman',Times,serif;color:var(--brown);}
+    .site-title a:hover{color:var(--brown);text-decoration:none;}
     header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}

--- a/services.html
+++ b/services.html
@@ -35,7 +35,8 @@
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
     .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    .site-title a{font-size:2rem;font-weight:bold;font-family:Georgia,'Times New Roman',Times,serif;color:var(--brown);}
+    .site-title a:hover{color:var(--brown);text-decoration:none;}
     header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}

--- a/videos.html
+++ b/videos.html
@@ -36,7 +36,8 @@
     .wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
     header.banner{background:var(--sand);border:4px solid var(--brown);padding:16px;color:var(--dark-brown);}
     .header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-    .site-title a{font-size:1.5rem;font-weight:bold;color:var(--nav-blue);}
+    .site-title a{font-size:2rem;font-weight:bold;font-family:Georgia,'Times New Roman',Times,serif;color:var(--brown);}
+    .site-title a:hover{color:var(--brown);text-decoration:none;}
     header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
     header.banner nav a{font-size:1.25rem;color:var(--nav-blue);}
     header.banner nav a:hover{color:var(--light-blue);}


### PR DESCRIPTION
## Summary
- use Georgia serif for site title across all pages
- enlarge site title and color it brown to match header frame
- keep site title color on hover

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cb93ccd4832aa10d8da13a78f584