### PR TITLE
Update social media icons and account links

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -48,7 +48,7 @@
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     .social-icons{display:flex;align-items:center;gap:1rem;}
-    .social-icons a{color:var(--nav-blue);}
+    .social-icons a{color:#000;}
     .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
       .header-content{flex-direction:column;}
@@ -89,27 +89,22 @@
         <div class="social-icons">
           <a href="https://github.com/loraatx" aria-label="GitHub">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="11"/>
-              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
-              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
-              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+              <path d="M12 .296c-6.63 0-12 5.373-12 12 0 5.302 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.807 5.624-5.48 5.92.432.372.816 1.102.816 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.296c0-6.627-5.373-12-12-12z"/>
             </svg>
           </a>
-          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+          <a href="https://www.youtube.com/@AustinLongRange" aria-label="YouTube">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
-              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+              <path d="M23.498 6.186a2.97 2.97 0 0 0-2.086-2.087C19.736 3.5 12 3.5 12 3.5s-7.736 0-9.412.6A2.97 2.97 0 0 0 .502 6.186C0 7.864 0 12 0 12s0 4.136.502 5.814a2.97 2.97 0 0 0 2.086 2.087c1.676.6 9.412.6 9.412.6s7.736 0 9.412-.6a2.97 2.97 0 0 0 2.086-2.087C24 16.136 24 12 24 12s0-4.136-.502-5.814zM9.75 15.02V8.98L15.5 12l-5.75 3.02z"/>
             </svg>
           </a>
-          <a href="https://x.com/loraatx" aria-label="X">
+          <a href="https://x.com/AustinLongRange" aria-label="X">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M2 0h5l5 7 5-7h5l-7.5 10.5L22 24h-5l-5-7-5 7H2l7.5-10.5L2 0z"/>
             </svg>
           </a>
-          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+          <a href="https://www.patreon.com/AustinLongRange" aria-label="Patreon">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="20"/>
-              <circle cx="15" cy="10" r="8"/>
+              <path d="M22.12 0H1.88C.84 0 0 .84 0 1.88v20.24C0 23.16.84 24 1.88 24h20.24C23.16 24 24 23.16 24 22.12V1.88C24 .84 23.16 0 22.12 0zM15.6 4.5c3.38 0 6.1 2.72 6.1 6.1s-2.72 6.1-6.1 6.1-6.1-2.72-6.1-6.1 2.72-6.1 6.1-6.1zM4.5 4.5h3v15h-3v-15z"/>
             </svg>
           </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     .social-icons{display:flex;align-items:center;gap:1rem;}
-    .social-icons a{color:var(--nav-blue);}
+    .social-icons a{color:#000;}
     .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
       .header-content{flex-direction:column;}
@@ -92,27 +92,22 @@
         <div class="social-icons">
           <a href="https://github.com/loraatx" aria-label="GitHub">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="11"/>
-              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
-              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
-              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+              <path d="M12 .296c-6.63 0-12 5.373-12 12 0 5.302 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.807 5.624-5.48 5.92.432.372.816 1.102.816 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.296c0-6.627-5.373-12-12-12z"/>
             </svg>
           </a>
-          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+          <a href="https://www.youtube.com/@AustinLongRange" aria-label="YouTube">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
-              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+              <path d="M23.498 6.186a2.97 2.97 0 0 0-2.086-2.087C19.736 3.5 12 3.5 12 3.5s-7.736 0-9.412.6A2.97 2.97 0 0 0 .502 6.186C0 7.864 0 12 0 12s0 4.136.502 5.814a2.97 2.97 0 0 0 2.086 2.087c1.676.6 9.412.6 9.412.6s7.736 0 9.412-.6a2.97 2.97 0 0 0 2.086-2.087C24 16.136 24 12 24 12s0-4.136-.502-5.814zM9.75 15.02V8.98L15.5 12l-5.75 3.02z"/>
             </svg>
           </a>
-          <a href="https://x.com/loraatx" aria-label="X">
+          <a href="https://x.com/AustinLongRange" aria-label="X">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M2 0h5l5 7 5-7h5l-7.5 10.5L22 24h-5l-5-7-5 7H2l7.5-10.5L2 0z"/>
             </svg>
           </a>
-          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+          <a href="https://www.patreon.com/AustinLongRange" aria-label="Patreon">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="20"/>
-              <circle cx="15" cy="10" r="8"/>
+              <path d="M22.12 0H1.88C.84 0 0 .84 0 1.88v20.24C0 23.16.84 24 1.88 24h20.24C23.16 24 24 23.16 24 22.12V1.88C24 .84 23.16 0 22.12 0zM15.6 4.5c3.38 0 6.1 2.72 6.1 6.1s-2.72 6.1-6.1 6.1-6.1-2.72-6.1-6.1 2.72-6.1 6.1-6.1zM4.5 4.5h3v15h-3v-15z"/>
             </svg>
           </a>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -48,7 +48,7 @@
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     .social-icons{display:flex;align-items:center;gap:1rem;}
-    .social-icons a{color:var(--nav-blue);}
+    .social-icons a{color:#000;}
     .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
       .header-content{flex-direction:column;}
@@ -89,27 +89,22 @@
         <div class="social-icons">
           <a href="https://github.com/loraatx" aria-label="GitHub">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="11"/>
-              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
-              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
-              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+              <path d="M12 .296c-6.63 0-12 5.373-12 12 0 5.302 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.807 5.624-5.48 5.92.432.372.816 1.102.816 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.296c0-6.627-5.373-12-12-12z"/>
             </svg>
           </a>
-          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+          <a href="https://www.youtube.com/@AustinLongRange" aria-label="YouTube">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
-              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+              <path d="M23.498 6.186a2.97 2.97 0 0 0-2.086-2.087C19.736 3.5 12 3.5 12 3.5s-7.736 0-9.412.6A2.97 2.97 0 0 0 .502 6.186C0 7.864 0 12 0 12s0 4.136.502 5.814a2.97 2.97 0 0 0 2.086 2.087c1.676.6 9.412.6 9.412.6s7.736 0 9.412-.6a2.97 2.97 0 0 0 2.086-2.087C24 16.136 24 12 24 12s0-4.136-.502-5.814zM9.75 15.02V8.98L15.5 12l-5.75 3.02z"/>
             </svg>
           </a>
-          <a href="https://x.com/loraatx" aria-label="X">
+          <a href="https://x.com/AustinLongRange" aria-label="X">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M2 0h5l5 7 5-7h5l-7.5 10.5L22 24h-5l-5-7-5 7H2l7.5-10.5L2 0z"/>
             </svg>
           </a>
-          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+          <a href="https://www.patreon.com/AustinLongRange" aria-label="Patreon">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="20"/>
-              <circle cx="15" cy="10" r="8"/>
+              <path d="M22.12 0H1.88C.84 0 0 .84 0 1.88v20.24C0 23.16.84 24 1.88 24h20.24C23.16 24 24 23.16 24 22.12V1.88C24 .84 23.16 0 22.12 0zM15.6 4.5c3.38 0 6.1 2.72 6.1 6.1s-2.72 6.1-6.1 6.1-6.1-2.72-6.1-6.1 2.72-6.1 6.1-6.1zM4.5 4.5h3v15h-3v-15z"/>
             </svg>
           </a>
         </div>

--- a/services.html
+++ b/services.html
@@ -47,7 +47,7 @@
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     .social-icons{display:flex;align-items:center;gap:1rem;}
-    .social-icons a{color:var(--nav-blue);}
+    .social-icons a{color:#000;}
     .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
       .header-content{flex-direction:column;}
@@ -88,27 +88,22 @@
         <div class="social-icons">
           <a href="https://github.com/loraatx" aria-label="GitHub">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="11"/>
-              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
-              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
-              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+              <path d="M12 .296c-6.63 0-12 5.373-12 12 0 5.302 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.807 5.624-5.48 5.92.432.372.816 1.102.816 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.296c0-6.627-5.373-12-12-12z"/>
             </svg>
           </a>
-          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+          <a href="https://www.youtube.com/@AustinLongRange" aria-label="YouTube">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
-              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+              <path d="M23.498 6.186a2.97 2.97 0 0 0-2.086-2.087C19.736 3.5 12 3.5 12 3.5s-7.736 0-9.412.6A2.97 2.97 0 0 0 .502 6.186C0 7.864 0 12 0 12s0 4.136.502 5.814a2.97 2.97 0 0 0 2.086 2.087c1.676.6 9.412.6 9.412.6s7.736 0 9.412-.6a2.97 2.97 0 0 0 2.086-2.087C24 16.136 24 12 24 12s0-4.136-.502-5.814zM9.75 15.02V8.98L15.5 12l-5.75 3.02z"/>
             </svg>
           </a>
-          <a href="https://x.com/loraatx" aria-label="X">
+          <a href="https://x.com/AustinLongRange" aria-label="X">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M2 0h5l5 7 5-7h5l-7.5 10.5L22 24h-5l-5-7-5 7H2l7.5-10.5L2 0z"/>
             </svg>
           </a>
-          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+          <a href="https://www.patreon.com/AustinLongRange" aria-label="Patreon">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="20"/>
-              <circle cx="15" cy="10" r="8"/>
+              <path d="M22.12 0H1.88C.84 0 0 .84 0 1.88v20.24C0 23.16.84 24 1.88 24h20.24C23.16 24 24 23.16 24 22.12V1.88C24 .84 23.16 0 22.12 0zM15.6 4.5c3.38 0 6.1 2.72 6.1 6.1s-2.72 6.1-6.1 6.1-6.1-2.72-6.1-6.1 2.72-6.1 6.1-6.1zM4.5 4.5h3v15h-3v-15z"/>
             </svg>
           </a>
         </div>

--- a/videos.html
+++ b/videos.html
@@ -48,7 +48,7 @@
     header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
     header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
     .social-icons{display:flex;align-items:center;gap:1rem;}
-    .social-icons a{color:var(--nav-blue);}
+    .social-icons a{color:#000;}
     .social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
     @media(max-width:600px){
       .header-content{flex-direction:column;}
@@ -89,27 +89,22 @@
         <div class="social-icons">
           <a href="https://github.com/loraatx" aria-label="GitHub">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="12" r="11"/>
-              <circle cx="8.5" cy="10.5" r="1.5" fill="#fff"/>
-              <circle cx="15.5" cy="10.5" r="1.5" fill="#fff"/>
-              <path d="M8 16c1.5-1 6.5-1 8 0" stroke="#fff" stroke-linecap="round"/>
+              <path d="M12 .296c-6.63 0-12 5.373-12 12 0 5.302 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.807 1.304 3.492.997.108-.776.418-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.807 5.624-5.48 5.92.432.372.816 1.102.816 2.222 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.296c0-6.627-5.373-12-12-12z"/>
             </svg>
           </a>
-          <a href="https://www.youtube.com/@loraatx" aria-label="YouTube">
+          <a href="https://www.youtube.com/@AustinLongRange" aria-label="YouTube">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="2" y="5" width="20" height="14" rx="3" ry="3"/>
-              <path d="M10 9l5 3-5 3V9z" fill="#fff"/>
+              <path d="M23.498 6.186a2.97 2.97 0 0 0-2.086-2.087C19.736 3.5 12 3.5 12 3.5s-7.736 0-9.412.6A2.97 2.97 0 0 0 .502 6.186C0 7.864 0 12 0 12s0 4.136.502 5.814a2.97 2.97 0 0 0 2.086 2.087c1.676.6 9.412.6 9.412.6s7.736 0 9.412-.6a2.97 2.97 0 0 0 2.086-2.087C24 16.136 24 12 24 12s0-4.136-.502-5.814zM9.75 15.02V8.98L15.5 12l-5.75 3.02z"/>
             </svg>
           </a>
-          <a href="https://x.com/loraatx" aria-label="X">
+          <a href="https://x.com/AustinLongRange" aria-label="X">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M2 2l20 20M22 2L2 22" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+              <path d="M2 0h5l5 7 5-7h5l-7.5 10.5L22 24h-5l-5-7-5 7H2l7.5-10.5L2 0z"/>
             </svg>
           </a>
-          <a href="https://www.patreon.com/loraatx" aria-label="Patreon">
+          <a href="https://www.patreon.com/AustinLongRange" aria-label="Patreon">
             <svg viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="3" y="2" width="4" height="20"/>
-              <circle cx="15" cy="10" r="8"/>
+              <path d="M22.12 0H1.88C.84 0 0 .84 0 1.88v20.24C0 23.16.84 24 1.88 24h20.24C23.16 24 24 23.16 24 22.12V1.88C24 .84 23.16 0 22.12 0zM15.6 4.5c3.38 0 6.1 2.72 6.1 6.1s-2.72 6.1-6.1 6.1-6.1-2.72-6.1-6.1 2.72-6.1 6.1-6.1zM4.5 4.5h3v15h-3v-15z"/>
             </svg>
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Replace social icons with branded SVGs and switch to black for consistency
- Update X, YouTube, and Patreon links to AustinLongRange accounts

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ceb9ae60832aab83d5ae68e7152d