### PR TITLE
Embed interactive terrain in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
     }
     footer{padding:40px 0;}
     img{max-width:100%;display:block;}
+    iframe{width:100%;height:480px;display:block;border:0;}
   </style>
 </head>
 <body>
@@ -121,7 +122,7 @@
       <div class="wrap">
         <div class="section-grid">
           <div class="media">
-            <img src="https://loraatx.city/img/about-img.webp">
+            <iframe src="https://loraatx.city/austin-3d-terrain/" title="Austin 3D Terrain" width="100%" height="480" style="border:0;"></iframe>
           </div>
           <div class="links">
             <p>About Aust Long Range:<br><br>Aust Long Range delivers bespoke, affordable map applications tailored to individual needs. Alongside these custom tools, the site provides access to related projects, datasets, and resources, creating a central hub for practical urban insight and collaboration.</p>


### PR DESCRIPTION
## Summary
- style: add iframe styling to match images
- about: replace static image with Austin 3D Terrain iframe

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b726059850832a9103c0509506e3b7