### PR TITLE
Fix about section map layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     }
     footer{padding:40px 0;}
     img{max-width:100%;display:block;}
-    iframe{width:100%;height:480px;display:block;border:0;}
+    iframe{width:100%;display:block;border:0;overflow:hidden;}
   </style>
 </head>
 <body>
@@ -122,7 +122,7 @@
       <div class="wrap">
         <div class="section-grid">
           <div class="media">
-            <iframe src="https://loraatx.city/austin-3d-terrain/" title="Austin 3D Terrain" width="100%" height="480" style="border:0;"></iframe>
+            <iframe src="https://loraatx.city/austin-3d-terrain/" title="Austin 3D Terrain" style="width:100%; aspect-ratio:16/9; border:0;" loading="lazy" scrolling="no"></iframe>
           </div>
           <div class="links">
             <p>About Aust Long Range:<br><br>Aust Long Range delivers bespoke, affordable map applications tailored to individual needs. Alongside these custom tools, the site provides access to related projects, datasets, and resources, creating a central hub for practical urban insight and collaboration.</p>


### PR DESCRIPTION
## Summary
- Remove fixed iframe height and hide overflow to prevent scrollbars
- Use aspect ratio for Austin 3D Terrain iframe and disable scrolling so it aligns with text

## Testing
- `npx --yes htmlhint index.html` (failed: 403 Forbidden)
- `npm test` (failed: could not find package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b75cd1666c832aa72b1621ead9d8d1