### PR TITLE
Redesign landing layout with hero header and map section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,42 +5,43 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>City Anatomy</title>
   <link href="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.css" rel="stylesheet" />
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      font-family: system-ui, sans-serif;
-      display: flex;
-      flex-direction: column;
-    }
-    header, footer {
-      text-align: center;
-      padding: 1rem;
-      background: #f8f8f8;
-      font-weight: bold;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-    }
-    #map {
-      flex: 1;
-      width: 100%;
-    }
-    footer {
-      font-weight: normal;
-      font-size: 0.9rem;
-    }
-  </style>
+  <link href="style.css" rel="stylesheet" />
 </head>
 <body>
-  <header>
-    <h1>City Anatomy Map</h1>
+  <header class="hero">
+    <div class="hero-content">
+      <img src="assets/header.png" alt="City Anatomy icon" class="hero-image" />
+      <h1 class="site-title">City Anatomy Map</h1>
+      <div class="social-links" aria-label="City Anatomy social media">
+        <a href="https://github.com/loraatx" aria-label="GitHub">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.1 3.29 9.42 7.86 10.95.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.35-1.29-1.71-1.29-1.71-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.26 3.4.97.11-.75.41-1.26.74-1.55-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.19-3.07-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.17.92-.26 1.9-.39 2.87-.39.97 0 1.95.13 2.87.39 2.2-1.48 3.17-1.17 3.17-1.17.63 1.59.23 2.76.11 3.05.74.8 1.19 1.82 1.19 3.07 0 4.4-2.68 5.36-5.24 5.64.43.37.8 1.1.8 2.22 0 1.6-.02 2.88-.02 3.27 0 .31.21.68.8.56C20.21 21.42 23.5 17.1 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
+        </a>
+        <a href="https://www.linkedin.com" aria-label="LinkedIn">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 8.75h3.96V21H3V8.75ZM9.75 8.75h3.8v1.68h.05c.53-1 1.82-2.05 3.74-2.05 4 0 4.74 2.63 4.74 6.05V21H18.1v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21H9.75V8.75Z"/></svg>
+        </a>
+        <a href="https://www.instagram.com" aria-label="Instagram">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 0 1 12 7.5Zm0 2A2.5 2.5 0 1 0 14.5 12 2.5 2.5 0 0 0 12 9.5Zm6.25-2.75a1 1 0 1 1-1 1 1 1 0 0 1 1-1Z"/></svg>
+        </a>
+      </div>
+    </div>
   </header>
 
-  <div id="map"></div>
+  <main>
+    <section class="intro">
+      <div class="intro-inner">
+        <h2>What is City Anatomy?</h2>
+        <p>City Anatomy helps you explore Austin’s streetscapes in three dimensions. Pan and zoom to view the urban fabric, building heights, and the vibrant neighborhoods that make the city unique.</p>
+      </div>
+    </section>
 
-  <footer>
-    <p>&copy; 2025 City Anatomy • Powered by 
-      <a href="https://openfreemap.org" target="_blank">OpenFreeMap</a>
+    <section class="map-section">
+      <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>&copy; 2025 City Anatomy &bull; Powered by
+      <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a>
     </p>
   </footer>
 

--- a/style.css
+++ b/style.css
@@ -1,102 +1,173 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Lora:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Lora:wght@600;700&display=swap');
 
-:root{
-  --bg:#1a1a1a;
-  --text:#e9e9f0;
-  --primary:#007bff;
-  --primary-light: #63b3ff;
-  --header-bg: #2c3e50;
-  --header-text: #ffffff;
-  --border-color: #333;
+:root {
+  --background: #f5f7fa;
+  --text: #1c1c28;
+  --accent: #0067c5;
+  --accent-light: #5ba8ff;
+  --surface: #ffffff;
+  --muted: #6f7780;
+  --border: #e1e6ee;
 }
 
-body{
-  margin:0;
-  padding:0;
-  background:var(--bg);
-  color:var(--text);
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
   font-family: 'Roboto', sans-serif;
-  font-size:16px;
-  line-height:1.6;
+  background: var(--background);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
 }
 
-.light{
-  --bg:#ffffff;
-  --text:#0e0e11;
-  --header-bg: #f8f9fa;
-  --header-text: #343a40;
-  --border-color: #dee2e6;
-}
-
-h1,h2{
-  margin:0 0 .5rem;
+h1,
+h2 {
+  margin: 0 0 0.5rem;
   font-family: 'Lora', serif;
+  font-weight: 700;
 }
 
-a{
-  color:var(--primary);
-  text-decoration:none;
-  transition: color 0.3s ease;
+p {
+  margin: 0 0 1rem;
+  line-height: 1.7;
+  color: var(--muted);
 }
 
-a:hover{
-  color:var(--primary-light);
-  text-decoration:underline;
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-ol{margin:0;padding-left:1.2rem;}
-li{margin-bottom:.5rem;}
-
-.links p{margin:0;padding:1rem;}
-#about .links p{font-size:1.125em;}
-.links p a:first-of-type{font-size:1.125em;font-family:'Lora',serif;}
-
-.wrap{max-width:1100px;margin:0 auto;padding:0 16px;}
-
-header.banner{
-  background:var(--header-bg);
-  border-bottom:4px solid var(--primary);
-  padding:16px;
-  color:var(--header-text);
+a:hover {
+  color: var(--accent-light);
 }
 
-.header-content{display:flex;align-items:center;justify-content:space-between;gap:1.5rem;}
-.site-title a{font-size:2rem;font-weight:bold;font-family:'Lora',serif;color:var(--header-text);}
-.site-title a:hover{color:var(--header-text);text-decoration:none;}
-
-header.banner nav{flex:1;display:flex;justify-content:center;align-items:center;gap:1.5rem;flex-wrap:wrap;}
-header.banner nav a{font-size:1.25rem;color:var(--header-text); transition: color 0.3s ease;}
-header.banner nav a:hover{color:var(--primary-light);}
-
-header.banner nav .theme-toggle{display:flex;align-items:center;}
-header.banner nav .theme-toggle input{display:none;}
-header.banner nav .theme-toggle .slider{position:relative;width:48px;height:24px;background:var(--primary);border-radius:12px;margin:0 .5rem; cursor: pointer;}
-header.banner nav .theme-toggle .slider::before{content:'';position:absolute;top:2px;left:2px;width:20px;height:20px;background:var(--text);border-radius:50%;transition:transform .3s;}
-header.banner nav .theme-toggle input:checked + .slider::before{transform:translateX(24px);}
-header.banner nav .theme-toggle .sun,header.banner nav .theme-toggle .moon{font-size:1.25rem;}
-
-.social-icons{display:flex;align-items:center;gap:1rem;}
-.social-icons a{color:var(--header-text); transition: color 0.3s ease;}
-.social-icons a:hover{color: var(--primary-light);}
-.social-icons svg{width:24px;height:24px;display:block;fill:currentColor;}
-
-@media(max-width:600px){
-  .header-content{flex-direction:column;}
-  header.banner nav{flex-direction:column;gap:.75rem;}
-  header.banner nav a{font-size:1rem;}
+.hero {
+  background: var(--surface);
+  padding: 3rem 1.5rem 2rem;
+  text-align: center;
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 12px 30px rgba(15, 25, 45, 0.08);
 }
 
-section{padding:32px 0;border-bottom:1px solid var(--border-color);}
-section:last-of-type{border-bottom:none;}
-
-.section-grid{display:flex;flex-direction:column;gap:16px;}
-.section-grid .media,.section-grid .links{flex:1;}
-
-@media(min-width:720px){
-  .section-grid{flex-direction:row;align-items:flex-start; gap: 2rem;}
-  .section-grid.reverse{flex-direction:row-reverse;}
+.hero-content {
+  max-width: 600px;
+  margin: 0 auto;
 }
 
-footer{padding:40px 0; color: #6c757d;}
-img{max-width:100%;display:block; border-radius: 8px;}
-iframe{width:100%;display:block;border:0;overflow:hidden; border-radius: 8px;}
+.hero-image {
+  width: 120px;
+  height: auto;
+  margin: 0 auto 1.5rem;
+}
+
+.site-title {
+  font-size: 2rem;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+
+.social-links {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+}
+
+.social-links a {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 103, 197, 0.08);
+  color: var(--accent);
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.social-links a:hover {
+  transform: translateY(-2px);
+  background: var(--accent);
+  color: #fff;
+}
+
+.social-links svg {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.intro {
+  padding: 3rem 1.5rem 2rem;
+  text-align: center;
+}
+
+.intro-inner {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.map-section {
+  flex: 1;
+  display: flex;
+  padding: 0 0 2.5rem;
+}
+
+#map {
+  flex: 1;
+  min-height: 420px;
+  width: 100%;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(15, 25, 45, 0.05);
+}
+
+.page-footer {
+  text-align: center;
+  padding: 2rem 1.5rem 3rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.page-footer a {
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2.5rem 1.25rem 1.75rem;
+  }
+
+  .hero-image {
+    width: 96px;
+  }
+
+  .site-title {
+    font-size: 1.75rem;
+  }
+
+  .intro {
+    padding: 2.5rem 1.25rem 1.5rem;
+  }
+
+  .map-section {
+    padding-bottom: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the plain header with a centered hero that displays the header artwork, smaller site title, and social links
- add descriptive intro copy and keep the interactive map in its own flexible section for better layout balance
- refresh the global styles to match the new layout, including typography, spacing, and responsive tweaks

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc29f255a0832a86cbd0cea9422cd3