### PR TITLE
Simplify layout and add section anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,16 @@
   <link href="style.css" rel="stylesheet" />
 </head>
 <body>
-  <header class="hero">
+  <header id="top" class="hero">
     <div class="hero-content">
       <img src="assets/header.png" alt="City Anatomy icon" class="hero-image" />
       <h1 class="site-title">City Anatomy Map</h1>
+      <nav class="section-links" aria-label="Quick links to page sections">
+        <a href="#substack">Substack</a>
+        <a href="#services">Services</a>
+        <a href="#apps">Apps</a>
+        <a href="#maps">Maps</a>
+      </nav>
       <div class="social-links" aria-label="City Anatomy social media">
         <a href="https://github.com/loraatx" aria-label="GitHub">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.1 3.29 9.42 7.86 10.95.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.35-1.29-1.71-1.29-1.71-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.26 3.4.97.11-.75.41-1.26.74-1.55-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.19-3.07-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.17.92-.26 1.9-.39 2.87-.39.97 0 1.95.13 2.87.39 2.2-1.48 3.17-1.17 3.17-1.17.63 1.59.23 2.76.11 3.05.74.8 1.19 1.82 1.19 3.07 0 4.4-2.68 5.36-5.24 5.64.43.37.8 1.1.8 2.22 0 1.6-.02 2.88-.02 3.27 0 .31.21.68.8.56C20.21 21.42 23.5 17.1 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
@@ -27,15 +33,64 @@
   </header>
 
   <main>
-    <section class="intro">
-      <div class="intro-inner">
-        <h2>What is City Anatomy?</h2>
-        <p>City Anatomy helps you explore Austin’s streetscapes in three dimensions. Pan and zoom to view the urban fabric, building heights, and the vibrant neighborhoods that make the city unique.</p>
+    <section class="map-section">
+      <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
+    </section>
+
+    <section id="substack" class="info-section">
+      <div class="section-inner">
+        <h2>Substack</h2>
+        <p>Details about the City Anatomy Substack will appear here soon.</p>
+        <div class="section-nav" aria-label="Section navigation">
+          <a href="#top">Back to top</a>
+          <span aria-hidden="true">•</span>
+          <a href="#services">Services</a>
+          <a href="#apps">Apps</a>
+          <a href="#maps">Maps</a>
+        </div>
       </div>
     </section>
 
-    <section class="map-section">
-      <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
+    <section id="services" class="info-section">
+      <div class="section-inner">
+        <h2>Services</h2>
+        <p>Outline the services offered by City Anatomy in this space.</p>
+        <div class="section-nav" aria-label="Section navigation">
+          <a href="#top">Back to top</a>
+          <span aria-hidden="true">•</span>
+          <a href="#substack">Substack</a>
+          <a href="#apps">Apps</a>
+          <a href="#maps">Maps</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="apps" class="info-section">
+      <div class="section-inner">
+        <h2>Apps</h2>
+        <p>Share information about apps and tools connected to City Anatomy.</p>
+        <div class="section-nav" aria-label="Section navigation">
+          <a href="#top">Back to top</a>
+          <span aria-hidden="true">•</span>
+          <a href="#substack">Substack</a>
+          <a href="#services">Services</a>
+          <a href="#maps">Maps</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="maps" class="info-section">
+      <div class="section-inner">
+        <h2>Maps</h2>
+        <p>Highlight additional map resources and projects in this section.</p>
+        <div class="section-nav" aria-label="Section navigation">
+          <a href="#top">Back to top</a>
+          <span aria-hidden="true">•</span>
+          <a href="#substack">Substack</a>
+          <a href="#services">Services</a>
+          <a href="#apps">Apps</a>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -77,6 +77,18 @@ a:hover {
   color: var(--text);
 }
 
+.section-links {
+  margin: 1rem 0 0;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.section-links a {
+  font-weight: 500;
+}
+
 .social-links {
   margin-top: 1.25rem;
   display: flex;
@@ -114,16 +126,6 @@ main {
   flex-direction: column;
 }
 
-.intro {
-  padding: 3rem 1.5rem 2rem;
-  text-align: center;
-}
-
-.intro-inner {
-  max-width: 640px;
-  margin: 0 auto;
-}
-
 .map-section {
   flex: 1;
   display: flex;
@@ -137,6 +139,29 @@ main {
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
   box-shadow: inset 0 1px 0 rgba(15, 25, 45, 0.05);
+}
+
+.info-section {
+  padding: 2.5rem 1.5rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.section-inner {
+  max-width: 640px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.section-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.section-nav span {
+  color: var(--muted);
 }
 
 .page-footer {
@@ -163,11 +188,11 @@ main {
     font-size: 1.75rem;
   }
 
-  .intro {
-    padding: 2.5rem 1.25rem 1.5rem;
-  }
-
   .map-section {
     padding-bottom: 2rem;
+  }
+
+  .info-section {
+    padding: 2rem 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- remove the intro content above the map and insert quick links beneath the site icon
- add placeholder sections for Substack, Services, Apps, and Maps with simple navigation links
- refresh styles to support the new section navigation layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc2efa31c4832abf1cc3311ad20d4c