### PR TITLE
Adjust hero layout and navigation separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,17 +18,6 @@
         <a href="#apps">Apps</a>
         <a href="#maps">Maps</a>
       </nav>
-      <div class="social-links" aria-label="City Anatomy social media">
-        <a href="https://github.com/loraatx" aria-label="GitHub">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.1 3.29 9.42 7.86 10.95.58.11.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.53-1.35-1.29-1.71-1.29-1.71-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.78 2.73 1.26 3.4.97.11-.75.41-1.26.74-1.55-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.19-3.07-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.17.92-.26 1.9-.39 2.87-.39.97 0 1.95.13 2.87.39 2.2-1.48 3.17-1.17 3.17-1.17.63 1.59.23 2.76.11 3.05.74.8 1.19 1.82 1.19 3.07 0 4.4-2.68 5.36-5.24 5.64.43.37.8 1.1.8 2.22 0 1.6-.02 2.88-.02 3.27 0 .31.21.68.8.56C20.21 21.42 23.5 17.1 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
-        </a>
-        <a href="https://www.linkedin.com" aria-label="LinkedIn">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5ZM3 8.75h3.96V21H3V8.75ZM9.75 8.75h3.8v1.68h.05c.53-1 1.82-2.05 3.74-2.05 4 0 4.74 2.63 4.74 6.05V21H18.1v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85V21H9.75V8.75Z"/></svg>
-        </a>
-        <a href="https://www.instagram.com" aria-label="Instagram">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 0 1 12 7.5Zm0 2A2.5 2.5 0 1 0 14.5 12 2.5 2.5 0 0 0 12 9.5Zm6.25-2.75a1 1 0 1 1-1 1 1 1 0 0 1 1-1Z"/></svg>
-        </a>
-      </div>
     </div>
   </header>
 
@@ -43,7 +32,6 @@
         <p>Details about the City Anatomy Substack will appear here soon.</p>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
-          <span aria-hidden="true">•</span>
           <a href="#services">Services</a>
           <a href="#apps">Apps</a>
           <a href="#maps">Maps</a>
@@ -57,7 +45,6 @@
         <p>Outline the services offered by City Anatomy in this space.</p>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
-          <span aria-hidden="true">•</span>
           <a href="#substack">Substack</a>
           <a href="#apps">Apps</a>
           <a href="#maps">Maps</a>
@@ -71,7 +58,6 @@
         <p>Share information about apps and tools connected to City Anatomy.</p>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
-          <span aria-hidden="true">•</span>
           <a href="#substack">Substack</a>
           <a href="#services">Services</a>
           <a href="#maps">Maps</a>
@@ -85,7 +71,6 @@
         <p>Highlight additional map resources and projects in this section.</p>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
-          <span aria-hidden="true">•</span>
           <a href="#substack">Substack</a>
           <a href="#services">Services</a>
           <a href="#apps">Apps</a>

--- a/style.css
+++ b/style.css
@@ -27,6 +27,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100%;
+  text-align: center;
 }
 
 h1,
@@ -54,7 +55,7 @@ a:hover {
 
 .hero {
   background: var(--surface);
-  padding: 3rem 1.5rem 2rem;
+  padding: 2rem 1.5rem 1.5rem;
   text-align: center;
   border-bottom: 1px solid var(--border);
   box-shadow: 0 12px 30px rgba(15, 25, 45, 0.08);
@@ -66,9 +67,9 @@ a:hover {
 }
 
 .hero-image {
-  width: 120px;
+  width: 88px;
   height: auto;
-  margin: 0 auto 1.5rem;
+  margin: 0 auto 1rem;
 }
 
 .site-title {
@@ -78,46 +79,21 @@ a:hover {
 }
 
 .section-links {
-  margin: 1rem 0 0;
-  display: flex;
+  margin: 1rem 0 0.5rem;
+  display: inline-flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 0.75rem;
 }
 
 .section-links a {
   font-weight: 500;
+  padding: 0 0.5rem;
 }
 
-.social-links {
-  margin-top: 1.25rem;
-  display: flex;
-  justify-content: center;
-  gap: 1.25rem;
-}
-
-.social-links a {
-  display: inline-flex;
-  width: 40px;
-  height: 40px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: rgba(0, 103, 197, 0.08);
-  color: var(--accent);
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
-}
-
-.social-links a:hover {
-  transform: translateY(-2px);
-  background: var(--accent);
-  color: #fff;
-}
-
-.social-links svg {
-  width: 22px;
-  height: 22px;
-  fill: currentColor;
+.section-links a + a::before {
+  content: '|';
+  color: var(--muted);
+  margin: 0 0.5rem;
 }
 
 main {
@@ -156,12 +132,17 @@ main {
 .section-nav {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
   font-size: 0.95rem;
 }
 
-.section-nav span {
+.section-nav a {
+  padding: 0 0.5rem;
+}
+
+.section-nav a + a::before {
+  content: '|';
   color: var(--muted);
+  margin: 0 0.5rem;
 }
 
 .page-footer {
@@ -177,11 +158,11 @@ main {
 
 @media (max-width: 600px) {
   .hero {
-    padding: 2.5rem 1.25rem 1.75rem;
+    padding: 1.75rem 1.25rem 1.5rem;
   }
 
   .hero-image {
-    width: 96px;
+    width: 72px;
   }
 
   .site-title {


### PR DESCRIPTION
## Summary
- shrink the hero image and padding to reduce the height of the top section while centering content across the page
- remove unused social media icon markup and styles from the header
- add visual separators between section navigation links in the hero and section footers for clearer spacing

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc32b4698c832a9b2e97d671b063ba