### PR TITLE
Use Poppins for site titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>City Anatomy</title>
   <link href="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap"
+    rel="stylesheet"
+  />
   <link href="style.css" rel="stylesheet" />
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -31,7 +31,7 @@ body {
 h1,
 h2 {
   margin: 0 0 0.5rem;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Poppins', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 700;
 }
 
@@ -74,6 +74,7 @@ a:hover {
   font-size: 2rem;
   letter-spacing: 0.02em;
   color: var(--text);
+  font-family: 'Poppins', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 .section-links {


### PR DESCRIPTION
## Summary
- load the Poppins family from Google Fonts
- apply the new sans-serif styling to the page headings and hero title for a modern look

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc421c1334832abfa4799c25c35b66