### PR TITLE
Add Substack subscribe embed to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,16 @@
     <section id="substack" class="info-section">
       <div class="section-inner">
         <h2>Substack</h2>
-        <p>Details about the City Anatomy Substack will appear here soon.</p>
+        <p>Subscribe to the City Anatomy Substack for the latest updates.</p>
+        <iframe
+          src="https://cityanatomy.substack.com/embed"
+          width="480"
+          height="320"
+          style="border: 1px solid #EEE; background: white;"
+          frameborder="0"
+          scrolling="no"
+          title="City Anatomy Substack Subscription"
+        ></iframe>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
           <a href="#services">Services</a>


### PR DESCRIPTION
## Summary
- replace the placeholder copy in the Substack section with the City Anatomy subscribe embed
- add a short description encouraging visitors to subscribe

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc4e7e7334832a8366a98dacbe5ce9