### PR TITLE
Remove Substack subscribe embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,7 @@
     <section id="substack" class="info-section">
       <div class="section-inner">
         <h2>Substack</h2>
-        <p>Subscribe to the City Anatomy Substack for the latest updates.</p>
-        <iframe
-          src="https://cityanatomy.substack.com/embed"
-          width="480"
-          height="320"
-          style="border: 1px solid #EEE; background: white;"
-          frameborder="0"
-          scrolling="no"
-          title="City Anatomy Substack Subscription"
-        ></iframe>
+        <p>Details about the City Anatomy Substack will appear here soon.</p>
         <div class="section-nav" aria-label="Section navigation">
           <a href="#top">Back to top</a>
           <a href="#services">Services</a>


### PR DESCRIPTION
## Summary
- remove the Substack subscribe iframe from the homepage
- restore the placeholder copy in the Substack section

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc5cc839d0832a94742dee967525d6