### PR TITLE
Restyle landing hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,22 +14,28 @@
   <link href="style.css" rel="stylesheet" />
 </head>
 <body>
-  <header id="top" class="hero">
-    <div class="hero-content">
-      <img src="assets/header.png" alt="City Anatomy icon" class="hero-image" />
-      <h1 class="site-title">City Anatomy - Austin, Tx</h1>
-      <nav class="section-links" aria-label="Quick links to page sections">
-        <a href="#substack">Substack</a>
-        <a href="#services">Services</a>
-        <a href="#apps">Apps</a>
-        <a href="#maps">Maps</a>
-      </nav>
-    </div>
+  <header id="top" class="topbar">
+    <div class="brand">City Anatomy</div>
+    <nav class="primary-nav" aria-label="Main navigation">
+      <a href="#substack">Substack</a>
+      <a href="#services">Services</a>
+      <a href="#apps">Apps</a>
+      <a href="#maps">Maps</a>
+    </nav>
   </header>
 
   <main>
-    <section class="map-section">
+    <section class="map-hero">
       <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
+      <div class="hero-overlay">
+        <p class="eyebrow">Austin, Texas</p>
+        <h1 class="site-title">City Anatomy</h1>
+        <p class="lede">A living 3D view of the urban fabric, from street grid to skyline.</p>
+        <div class="cta-group">
+          <a class="button primary" href="#maps">Explore Maps</a>
+          <a class="button ghost" href="#services">See Services</a>
+        </div>
+      </div>
     </section>
 
     <section id="substack" class="info-section">

--- a/style.css
+++ b/style.css
@@ -25,7 +25,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  text-align: center;
 }
 
 h1,
@@ -51,48 +50,52 @@ a:hover {
   color: var(--accent-light);
 }
 
-.hero {
-  background: var(--surface);
-  padding: 2rem 1.5rem 1.5rem;
-  text-align: center;
+.topbar {
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.75rem;
   border-bottom: 1px solid var(--border);
-  box-shadow: 0 12px 30px rgba(15, 25, 45, 0.08);
 }
 
-.hero-content {
-  max-width: 600px;
-  margin: 0 auto;
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
 }
 
-.hero-image {
-  width: 88px;
-  height: auto;
-  margin: 0 auto 1rem;
+.primary-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.primary-nav a {
+  color: var(--text);
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus-visible {
+  background: var(--background);
+  color: var(--accent);
 }
 
 .site-title {
-  font-size: 2rem;
+  font-size: 2.4rem;
   letter-spacing: 0.02em;
   color: var(--text);
   font-family: 'Poppins', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
-
-.section-links {
-  margin: 1rem 0 0.5rem;
-  display: inline-flex;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.section-links a {
-  font-weight: 500;
-  padding: 0 0.5rem;
-}
-
-.section-links a + a::before {
-  content: '|';
-  color: var(--muted);
-  margin: 0 0.5rem;
+  margin: 0.25rem 0;
 }
 
 main {
@@ -101,19 +104,83 @@ main {
   flex-direction: column;
 }
 
-.map-section {
+.map-hero {
+  position: relative;
   flex: 1;
   display: flex;
-  padding: 0 0 2.5rem;
+  min-height: 70vh;
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
 }
 
 #map {
   flex: 1;
-  min-height: 420px;
+  min-height: 70vh;
   width: 100%;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  box-shadow: inset 0 1px 0 rgba(15, 25, 45, 0.05);
+}
+
+.hero-overlay {
+  position: absolute;
+  top: 12%;
+  left: 8%;
+  max-width: 520px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(6px);
+  border-radius: 18px;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 24px 50px rgba(18, 38, 64, 0.15);
+  text-align: left;
+}
+
+.eyebrow {
+  margin: 0;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.lede {
+  margin: 0 0 1.25rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cta-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.1rem;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.2s ease;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 14px 30px rgba(0, 103, 197, 0.3);
+}
+
+.button.ghost {
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(15, 25, 45, 0.16);
 }
 
 .info-section {
@@ -156,20 +223,33 @@ main {
 }
 
 @media (max-width: 600px) {
-  .hero {
-    padding: 1.75rem 1.25rem 1.5rem;
+  .topbar {
+    padding: 0.75rem 1.1rem;
   }
 
-  .hero-image {
-    width: 72px;
+  .primary-nav {
+    gap: 0.5rem;
+    font-size: 0.9rem;
   }
 
   .site-title {
     font-size: 1.75rem;
   }
 
-  .map-section {
-    padding-bottom: 2rem;
+  .map-hero,
+  #map {
+    min-height: 65vh;
+  }
+
+  .hero-overlay {
+    position: static;
+    margin: -3rem 1rem 1rem;
+    max-width: none;
+    text-align: left;
+  }
+
+  .cta-group {
+    flex-wrap: wrap;
   }
 
   .info-section {


### PR DESCRIPTION
## Summary
- redesign the header into a compact topbar with navigation links for Substack, Services, Apps, and Maps
- move the 3D map directly under the header and add a deck.gl-style hero overlay with call-to-action buttons
- refresh supporting styles for the map hero, buttons, and responsive layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb286910c832a9a3be2bb3cced164)