### PR TITLE
Restyle header and add theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,21 @@
 </head>
 <body>
   <header id="top" class="topbar">
-    <div class="brand">City Anatomy</div>
-    <nav class="primary-nav" aria-label="Main navigation">
-      <a href="#substack">Substack</a>
-      <a href="#services">Services</a>
-      <a href="#apps">Apps</a>
-      <a href="#maps">Maps</a>
-    </nav>
+    <div class="topbar-left">
+      <div class="brand">City Anatomy</div>
+      <nav class="primary-nav" aria-label="Main navigation">
+        <a href="#top">Docs</a>
+        <a href="#top">Examples</a>
+        <a href="#top">Showcase</a>
+        <a href="#top">Blog</a>
+      </nav>
+    </div>
+    <div class="topbar-right">
+      <button class="theme-toggle" type="button" aria-label="Toggle color scheme">
+        <span class="toggle-icon">☀️</span>
+        <span class="toggle-label">Light</span>
+      </button>
+    </div>
   </header>
 
   <main>
@@ -38,57 +46,6 @@
       </div>
     </section>
 
-    <section id="substack" class="info-section">
-      <div class="section-inner">
-        <h2>Substack</h2>
-        <p>Details about the City Anatomy Substack will appear here soon.</p>
-        <div class="section-nav" aria-label="Section navigation">
-          <a href="#top">Back to top</a>
-          <a href="#services">Services</a>
-          <a href="#apps">Apps</a>
-          <a href="#maps">Maps</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="services" class="info-section">
-      <div class="section-inner">
-        <h2>Services</h2>
-        <p>Outline the services offered by City Anatomy in this space.</p>
-        <div class="section-nav" aria-label="Section navigation">
-          <a href="#top">Back to top</a>
-          <a href="#substack">Substack</a>
-          <a href="#apps">Apps</a>
-          <a href="#maps">Maps</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="apps" class="info-section">
-      <div class="section-inner">
-        <h2>Apps</h2>
-        <p>Share information about apps and tools connected to City Anatomy.</p>
-        <div class="section-nav" aria-label="Section navigation">
-          <a href="#top">Back to top</a>
-          <a href="#substack">Substack</a>
-          <a href="#services">Services</a>
-          <a href="#maps">Maps</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="maps" class="info-section">
-      <div class="section-inner">
-        <h2>Maps</h2>
-        <p>Highlight additional map resources and projects in this section.</p>
-        <div class="section-nav" aria-label="Section navigation">
-          <a href="#top">Back to top</a>
-          <a href="#substack">Substack</a>
-          <a href="#services">Services</a>
-          <a href="#apps">Apps</a>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer class="page-footer">
@@ -142,6 +99,30 @@
         },
         labelLayerId
       );
+    });
+
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = initialTheme;
+
+    const themeToggle = document.querySelector('.theme-toggle');
+    const toggleIcon = themeToggle.querySelector('.toggle-icon');
+    const toggleLabel = themeToggle.querySelector('.toggle-label');
+
+    const updateToggleUI = (theme) => {
+      toggleIcon.textContent = theme === 'dark' ? '🌙' : '☀️';
+      toggleLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    };
+
+    updateToggleUI(initialTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme;
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateToggleUI(nextTheme);
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -6,6 +6,18 @@
   --surface: #ffffff;
   --muted: #6f7780;
   --border: #e1e6ee;
+  --shadow: rgba(15, 25, 45, 0.12);
+}
+
+:root[data-theme='dark'] {
+  --background: #0e1117;
+  --text: #f5f7fa;
+  --accent: #4cc3ff;
+  --accent-light: #8ad7ff;
+  --surface: #161b23;
+  --muted: #c0c7d1;
+  --border: #2a3040;
+  --shadow: rgba(0, 0, 0, 0.45);
 }
 
 * {
@@ -51,43 +63,74 @@ a:hover {
 }
 
 .topbar {
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(14px);
   position: sticky;
   top: 0;
   z-index: 10;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.85rem 1.75rem;
+  gap: 1rem;
+  padding: 1.15rem 1.9rem;
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 6px 16px var(--shadow);
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.topbar-right {
+  margin-left: auto;
 }
 
 .brand {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-size: 0.95rem;
+  font-size: 1rem;
 }
 
 .primary-nav {
   display: inline-flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.25rem;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1rem;
 }
 
 .primary-nav a {
   color: var(--text);
-  padding: 0.35rem 0.6rem;
-  border-radius: 6px;
+  padding: 0.35rem 0;
+  border-radius: 8px;
+  position: relative;
 }
 
 .primary-nav a:hover,
 .primary-nav a:focus-visible {
-  background: var(--background);
   color: var(--accent);
+}
+
+.primary-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.5rem;
+  width: 100%;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 99px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus-visible::after {
+  transform: scaleX(1);
 }
 
 .site-title {
@@ -130,6 +173,12 @@ main {
   padding: 1.5rem 1.75rem;
   box-shadow: 0 24px 50px rgba(18, 38, 64, 0.15);
   text-align: left;
+}
+
+:root[data-theme='dark'] .hero-overlay {
+  background: rgba(22, 27, 35, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.6);
 }
 
 .eyebrow {
@@ -220,6 +269,28 @@ main {
 
 .page-footer a {
   font-weight: 600;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.15s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px var(--shadow);
+  border-color: var(--accent);
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Restyle the header with left-aligned navigation and a right-aligned theme toggle inspired by the deck.gl layout
- Add light/dark theme support with updated surface, text, and overlay styling
- Remove placeholder sections below the map, leaving the main area ready for new content

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb59e6d40832ab6e62b98739c9fb5)