### PR TITLE
Add placeholder news feed card on map hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,34 @@
         <p class="eyebrow">Austin, Texas</p>
         <h1 class="site-title">City Anatomy</h1>
         <p class="lede">A living 3D view of the urban fabric, from street grid to skyline.</p>
-        <div class="cta-group">
-          <a class="button primary" href="#maps">Explore Maps</a>
-          <a class="button ghost" href="#services">See Services</a>
+        <div class="news-feed" aria-live="polite">
+          <div class="feed-header">
+            <h2 class="feed-title">Austin planning news</h2>
+            <p class="feed-subtitle">Fresh headlines will appear here as the feed comes online.</p>
+          </div>
+          <ul class="feed-list">
+            <li class="feed-item">
+              <span class="feed-dot" aria-hidden="true"></span>
+              <div>
+                <p class="feed-headline">City releases preliminary street redesign concepts for downtown corridors.</p>
+                <p class="feed-meta">Placeholder update &bull; Refresh coming soon</p>
+              </div>
+            </li>
+            <li class="feed-item">
+              <span class="feed-dot" aria-hidden="true"></span>
+              <div>
+                <p class="feed-headline">Transit task force prepares priorities for the next bond cycle.</p>
+                <p class="feed-meta">Stay tuned for live links and sources</p>
+              </div>
+            </li>
+            <li class="feed-item">
+              <span class="feed-dot" aria-hidden="true"></span>
+              <div>
+                <p class="feed-headline">Planning Commission reviews updates to the Imagine Austin roadmap.</p>
+                <p class="feed-meta">More coverage will be streamed right here</p>
+              </div>
+            </li>
+          </ul>
         </div>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -196,40 +196,71 @@ main {
   line-height: 1.6;
 }
 
-.cta-group {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
+.news-feed {
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
 }
 
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.65rem 1.1rem;
-  border-radius: 10px;
-  font-weight: 700;
+:root[data-theme='dark'] .news-feed {
+  background: color-mix(in srgb, var(--surface) 75%, transparent);
+  border-color: color-mix(in srgb, var(--border) 80%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.feed-header {
+  margin-bottom: 0.75rem;
+}
+
+.feed-title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.feed-subtitle {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
   font-size: 0.95rem;
-  border: 1px solid transparent;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.2s ease;
 }
 
-.button.primary {
-  background: var(--accent);
-  color: white;
-  box-shadow: 0 14px 30px rgba(0, 103, 197, 0.3);
+.feed-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
 }
 
-.button.ghost {
-  background: rgba(255, 255, 255, 0.9);
+.feed-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem 0.65rem;
+  align-items: start;
+}
+
+.feed-dot {
+  width: 10px;
+  height: 10px;
+  margin-top: 0.2rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff 0%, #fff 30%, var(--accent) 31%);
+  border: 2px solid color-mix(in srgb, var(--accent) 45%, var(--accent-light));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.feed-headline {
+  margin: 0;
   color: var(--text);
-  border-color: var(--border);
+  font-weight: 700;
+  line-height: 1.45;
 }
 
-.button:hover,
-.button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 18px 36px rgba(15, 25, 45, 0.16);
+.feed-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .info-section {


### PR DESCRIPTION
## Summary
- replace the hero CTA buttons with a placeholder Austin planning news feed panel
- add structured markup for sample headlines and supporting text
- style the feed card to match the hero overlay in both light and dark themes

## Testing
- Not run (static site changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ebbc20e30832a9aecec172400d616)