### PR TITLE
Add navigation pages for maps, apps, examples, and substack

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Apps • City Anatomy</title>
+  <link rel="canonical" href="https://anatomy.city/apps" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-left">
+      <div class="brand">City Anatomy</div>
+      <nav class="primary-nav" aria-label="Main navigation">
+        <a href="/maps.html">Maps</a>
+        <a href="/apps.html">Apps</a>
+        <a href="/examples.html">Examples</a>
+        <a href="/substack.html">Substack</a>
+      </nav>
+    </div>
+    <div class="topbar-right">
+      <button class="theme-toggle" type="button" aria-label="Toggle color scheme">
+        <span class="toggle-icon">☀️</span>
+        <span class="toggle-label">Light</span>
+      </button>
+    </div>
+  </header>
+
+  <main class="content-page">
+    <div class="content-shell">
+      <p class="content-kicker">Apps</p>
+      <h1>Prototyping spatial tools</h1>
+      <p class="content-lede">
+        Lightweight applications that sit on top of the base maps. Expect experiments in
+        site selection, zoning lookups, climate overlays, and neighborhood storytelling.
+        Everything here is a sketch meant to gather feedback before turning into a full release.
+      </p>
+      <div class="placeholder-grid" aria-label="App ideas">
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Lot scanner</h2>
+          <p class="placeholder-meta">A quick parcel explorer that summarizes setbacks, FAR, and utilities.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Mobility companion</h2>
+          <p class="placeholder-meta">Concept for comparing transit, bike, and walk times to major anchors.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Heat & shade finder</h2>
+          <p class="placeholder-meta">Placeholder for a map that mixes tree canopy, impervious cover, and heat readings.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="page-footer">
+    <p>&copy; 2025 City Anatomy • Slug URL: <strong>anatomy.city/apps</strong></p>
+  </footer>
+
+  <script>
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = initialTheme;
+
+    const themeToggle = document.querySelector('.theme-toggle');
+    const toggleIcon = themeToggle.querySelector('.toggle-icon');
+    const toggleLabel = themeToggle.querySelector('.toggle-label');
+
+    const updateToggleUI = (theme) => {
+      toggleIcon.textContent = theme === 'dark' ? '🌙' : '☀️';
+      toggleLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    };
+
+    updateToggleUI(initialTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme;
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateToggleUI(nextTheme);
+    });
+  </script>
+</body>
+</html>

--- a/examples.html
+++ b/examples.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Examples • City Anatomy</title>
+  <link rel="canonical" href="https://anatomy.city/examples" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-left">
+      <div class="brand">City Anatomy</div>
+      <nav class="primary-nav" aria-label="Main navigation">
+        <a href="/maps.html">Maps</a>
+        <a href="/apps.html">Apps</a>
+        <a href="/examples.html">Examples</a>
+        <a href="/substack.html">Substack</a>
+      </nav>
+    </div>
+    <div class="topbar-right">
+      <button class="theme-toggle" type="button" aria-label="Toggle color scheme">
+        <span class="toggle-icon">☀️</span>
+        <span class="toggle-label">Light</span>
+      </button>
+    </div>
+  </header>
+
+  <main class="content-page">
+    <div class="content-shell">
+      <p class="content-kicker">Examples</p>
+      <h1>Pattern library & ingredients</h1>
+      <p class="content-lede">
+        A grab bag of reusable snippets for building the site: layout sketches, color ramps,
+        typography stacks, and small UI bits that keep the experience cohesive. Use these
+        placeholders as a living notebook for future builds.
+      </p>
+      <div class="placeholder-grid" aria-label="Design examples">
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Layer legend styles</h2>
+          <p class="placeholder-meta">Swatches, breakpoints, and notes for a multi-scale legend component.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Interaction patterns</h2>
+          <p class="placeholder-meta">Modal, drawer, and inline detail cards for handling map feature clicks.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Narrative panels</h2>
+          <p class="placeholder-meta">Stacked text and callout styles for explaining what a layer is showing.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="page-footer">
+    <p>&copy; 2025 City Anatomy • Slug URL: <strong>anatomy.city/examples</strong></p>
+  </footer>
+
+  <script>
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = initialTheme;
+
+    const themeToggle = document.querySelector('.theme-toggle');
+    const toggleIcon = themeToggle.querySelector('.toggle-icon');
+    const toggleLabel = themeToggle.querySelector('.toggle-label');
+
+    const updateToggleUI = (theme) => {
+      toggleIcon.textContent = theme === 'dark' ? '🌙' : '☀️';
+      toggleLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    };
+
+    updateToggleUI(initialTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme;
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateToggleUI(nextTheme);
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@
     <div class="topbar-left">
       <div class="brand">City Anatomy</div>
       <nav class="primary-nav" aria-label="Main navigation">
-        <a href="#top">Docs</a>
-        <a href="#top">Examples</a>
-        <a href="#top">Showcase</a>
-        <a href="#top">Blog</a>
+        <a href="/maps.html">Maps</a>
+        <a href="/apps.html">Apps</a>
+        <a href="/examples.html">Examples</a>
+        <a href="/substack.html">Substack</a>
       </nav>
     </div>
     <div class="topbar-right">

--- a/maps.html
+++ b/maps.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maps • City Anatomy</title>
+  <link rel="canonical" href="https://anatomy.city/maps" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-left">
+      <div class="brand">City Anatomy</div>
+      <nav class="primary-nav" aria-label="Main navigation">
+        <a href="/maps.html">Maps</a>
+        <a href="/apps.html">Apps</a>
+        <a href="/examples.html">Examples</a>
+        <a href="/substack.html">Substack</a>
+      </nav>
+    </div>
+    <div class="topbar-right">
+      <button class="theme-toggle" type="button" aria-label="Toggle color scheme">
+        <span class="toggle-icon">☀️</span>
+        <span class="toggle-label">Light</span>
+      </button>
+    </div>
+  </header>
+
+  <main class="content-page">
+    <div class="content-shell">
+      <p class="content-kicker">Maps</p>
+      <h1>Explorations of the urban grid</h1>
+      <p class="content-lede">
+        Preview in-progress map experiments that study Austin's neighborhoods, corridors,
+        and mobility systems. Each concept pairs cartography with narrative notes to explain
+        how the city works today and where it could go next.
+      </p>
+      <div class="placeholder-grid" aria-label="Map previews">
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Skyline massing study</h2>
+          <p class="placeholder-meta">3D extrusion preview comparing density bands along Congress Avenue.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Transit reliability map</h2>
+          <p class="placeholder-meta">Mock service map showing on-time performance windows across routes.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Greenways and water</h2>
+          <p class="placeholder-meta">Layered basemap highlighting the creek network, parks, and trailheads.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="page-footer">
+    <p>&copy; 2025 City Anatomy • Slug URL: <strong>anatomy.city/maps</strong></p>
+  </footer>
+
+  <script>
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = initialTheme;
+
+    const themeToggle = document.querySelector('.theme-toggle');
+    const toggleIcon = themeToggle.querySelector('.toggle-icon');
+    const toggleLabel = themeToggle.querySelector('.toggle-label');
+
+    const updateToggleUI = (theme) => {
+      toggleIcon.textContent = theme === 'dark' ? '🌙' : '☀️';
+      toggleLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    };
+
+    updateToggleUI(initialTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme;
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateToggleUI(nextTheme);
+    });
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -315,6 +315,61 @@ main {
   font-weight: 600;
 }
 
+.content-page {
+  flex: 1;
+  padding: 2.5rem 1.5rem 3rem;
+  background: var(--background);
+}
+
+.content-shell {
+  max-width: 860px;
+  margin: 0 auto;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 2rem 2.25rem;
+  box-shadow: 0 18px 38px var(--shadow);
+}
+
+.content-kicker {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--muted);
+  margin-bottom: 0.4rem;
+  font-size: 0.82rem;
+}
+
+.content-lede {
+  font-size: 1.1rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.placeholder-grid {
+  display: grid;
+  gap: 1rem;
+  margin: 1.4rem 0 0;
+}
+
+.placeholder-card {
+  border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+}
+
+.placeholder-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+}
+
+.placeholder-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .theme-toggle {
   display: inline-flex;
   align-items: center;

--- a/substack.html
+++ b/substack.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Substack • City Anatomy</title>
+  <link rel="canonical" href="https://anatomy.city/substack" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar-left">
+      <div class="brand">City Anatomy</div>
+      <nav class="primary-nav" aria-label="Main navigation">
+        <a href="/maps.html">Maps</a>
+        <a href="/apps.html">Apps</a>
+        <a href="/examples.html">Examples</a>
+        <a href="/substack.html">Substack</a>
+      </nav>
+    </div>
+    <div class="topbar-right">
+      <button class="theme-toggle" type="button" aria-label="Toggle color scheme">
+        <span class="toggle-icon">☀️</span>
+        <span class="toggle-label">Light</span>
+      </button>
+    </div>
+  </header>
+
+  <main class="content-page">
+    <div class="content-shell">
+      <p class="content-kicker">Substack</p>
+      <h1>Notes, drafts, and dispatches</h1>
+      <p class="content-lede">
+        The writing desk for City Anatomy lives on Substack. Here you'll find longform essays,
+        quick dispatches from field work, and weeknotes about what we're building. The posts
+        below are placeholders until the real feed is connected.
+      </p>
+      <div class="placeholder-grid" aria-label="Substack teasers">
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">How the skyline breathes</h2>
+          <p class="placeholder-meta">An outline for a story on wind, shade, and pocket parks downtown.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">A week inside the GIS stack</h2>
+          <p class="placeholder-meta">Notes from processing open data and tuning tiling pipelines.</p>
+        </div>
+        <div class="placeholder-card">
+          <h2 class="placeholder-title">Field trip: Waller Creek</h2>
+          <p class="placeholder-meta">Photo placeholders and captions from an evening walk along the trail.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="page-footer">
+    <p>&copy; 2025 City Anatomy • Slug URL: <strong>anatomy.city/substack</strong></p>
+  </footer>
+
+  <script>
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const storedTheme = localStorage.getItem('theme');
+    const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = initialTheme;
+
+    const themeToggle = document.querySelector('.theme-toggle');
+    const toggleIcon = themeToggle.querySelector('.toggle-icon');
+    const toggleLabel = themeToggle.querySelector('.toggle-label');
+
+    const updateToggleUI = (theme) => {
+      toggleIcon.textContent = theme === 'dark' ? '🌙' : '☀️';
+      toggleLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    };
+
+    updateToggleUI(initialTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const currentTheme = document.documentElement.dataset.theme;
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = nextTheme;
+      localStorage.setItem('theme', nextTheme);
+      updateToggleUI(nextTheme);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update the header navigation to link to Maps, Apps, Examples, and Substack pages
- add shared content-page styles for placeholder sections
- create maps, apps, examples, and substack HTML pages with filler copy and slug-friendly canonicals

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1ba703cc832a98449958e68b7a7e)