### PR TITLE
Link header brand and remove map card title

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <body>
   <header id="top" class="topbar">
     <div class="topbar-left">
-      <div class="brand">City Anatomy</div>
+      <a class="brand" href="index.html">City Anatomy</a>
       <nav class="primary-nav" aria-label="Main navigation">
         <a href="/maps.html">Maps</a>
         <a href="/apps.html">Apps</a>
@@ -37,7 +37,6 @@
       <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
       <div class="hero-overlay">
         <p class="eyebrow">Austin, Texas</p>
-        <h1 class="site-title">City Anatomy</h1>
         <ul class="city-facts">
           <li><strong>Mayor:</strong> Kirk Watson</li>
           <li><strong>Population:</strong> ~997,600 (2025 City Projection) / ~2.4M (Metro)</li>


### PR DESCRIPTION
## Summary
- link the header brand text to the home page
- remove the City Anatomy title from the hero map card

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f27c0db5c832a9de0aacea56025e7)