### PR TITLE
Add drawing tools to map with feature tracking panel

### DIFF
--- a/apps/templateapp/app.js
+++ b/apps/templateapp/app.js
@@ -2,6 +2,8 @@ let map;
 let allFeatures = [];
 let filteredFeatures = [];
 let currentPopup;
+let draw;
+let drawEnabled = false;
 
 // --- 2D/3D view toggle ---
 
@@ -20,6 +22,73 @@ function initViewToggle() {
       map.setLayoutProperty("3d-buildings", "visibility", "none");
     }
   });
+}
+
+// --- Draw tools (mapbox-gl-draw) ---
+
+function initDraw() {
+  draw = new MapboxDraw({
+    displayControlsDefault: false,
+    controls: {
+      point: true,
+      line_string: true,
+      polygon: true,
+      trash: true
+    }
+  });
+
+  const btn = document.getElementById("drawToggle");
+  btn.addEventListener("click", () => {
+    drawEnabled = !drawEnabled;
+    btn.classList.toggle("active", drawEnabled);
+
+    const panel = document.getElementById("drawPanel");
+    panel.classList.toggle("hidden", !drawEnabled);
+
+    if (drawEnabled) {
+      map.addControl(draw, "top-right");
+    } else {
+      map.removeControl(draw);
+    }
+  });
+
+  document.getElementById("clearDrawBtn").addEventListener("click", () => {
+    draw.deleteAll();
+    updateDrawInfo();
+  });
+
+  map.on("draw.create", updateDrawInfo);
+  map.on("draw.update", updateDrawInfo);
+  map.on("draw.delete", updateDrawInfo);
+}
+
+function updateDrawInfo() {
+  const data = draw.getAll();
+  const infoEl = document.getElementById("drawInfo");
+
+  if (!data || data.features.length === 0) {
+    infoEl.textContent = "Draw a shape on the map using the tools on the right.";
+    return;
+  }
+
+  const lines = data.features.map((f, i) => {
+    const type = f.geometry.type;
+    if (type === "Point") {
+      const [lng, lat] = f.geometry.coordinates;
+      return `Point ${i + 1}: ${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+    }
+    if (type === "LineString") {
+      const pts = f.geometry.coordinates.length;
+      return `Line ${i + 1}: ${pts} points`;
+    }
+    if (type === "Polygon") {
+      const pts = f.geometry.coordinates[0].length - 1;
+      return `Polygon ${i + 1}: ${pts} vertices`;
+    }
+    return `Feature ${i + 1}: ${type}`;
+  });
+
+  infoEl.innerHTML = lines.map(l => `<div class="draw-feature-row">${l}</div>`).join("");
 }
 
 // --- Theme toggle ---
@@ -78,6 +147,7 @@ async function init() {
   map.on("load", () => {
     add3DBuildings();
     initViewToggle();
+    initDraw();
     addPlacesLayers();
     buildFilters();
     buildTableHead();

--- a/apps/templateapp/index.html
+++ b/apps/templateapp/index.html
@@ -6,6 +6,7 @@
   <title>Map App</title>
 
   <link href="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.css" rel="stylesheet" />
+  <link href="https://unpkg.com/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css" rel="stylesheet" />
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
@@ -17,6 +18,7 @@
         <h1 id="pageTitle"></h1>
       </div>
       <div class="toolbar">
+        <button class="toolbar-btn" id="drawToggle" aria-label="Toggle draw tools">Draw</button>
         <button class="toolbar-btn" id="viewToggle" aria-label="Toggle 2D/3D view">2D</button>
         <button class="toolbar-btn" id="themeToggle" aria-label="Toggle dark mode"></button>
       </div>
@@ -24,6 +26,13 @@
 
     <section class="map-card">
       <div id="map"></div>
+      <div id="drawPanel" class="draw-panel hidden">
+        <div class="draw-panel-header">
+          <strong>Drawn Features</strong>
+          <button id="clearDrawBtn" class="draw-clear-btn" aria-label="Clear all drawn features">Clear All</button>
+        </div>
+        <div id="drawInfo" class="draw-info">Draw a shape on the map using the tools on the right.</div>
+      </div>
     </section>
 
     <section class="sub-header">
@@ -68,6 +77,7 @@
   </div>
 
   <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+  <script src="https://unpkg.com/@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.2/jspdf.umd.min.js"></script>
   <script src="./config.js"></script>
   <script src="./app.js"></script>

--- a/apps/templateapp/style.css
+++ b/apps/templateapp/style.css
@@ -608,3 +608,98 @@ tbody tr:last-child td {
     font-size: 13px;
   }
 }
+
+/* ── Draw Panel ──────────────────────────────────── */
+
+.draw-panel {
+  background: #fff;
+  border-top: 1px solid #e0e0e0;
+  padding: 12px 16px;
+  font-size: 13px;
+  color: #444;
+}
+
+.draw-panel.hidden {
+  display: none;
+}
+
+.draw-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.draw-clear-btn {
+  padding: 3px 10px;
+  border: 1.5px solid #d4d4d4;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  color: #666;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.draw-clear-btn:hover {
+  border-color: #e63946;
+  color: #e63946;
+  background: #fff5f5;
+}
+
+.draw-info {
+  color: #666;
+  line-height: 1.6;
+}
+
+.draw-feature-row {
+  padding: 2px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 12px;
+}
+
+.draw-feature-row:last-child {
+  border-bottom: none;
+}
+
+.toolbar-btn.active {
+  background: #e8f0fe;
+  border-color: #4285f4;
+  color: #1a73e8;
+}
+
+[data-theme="dark"] .draw-panel {
+  background: #16213e;
+  border-color: #2a2a4a;
+  color: #ddd;
+}
+
+[data-theme="dark"] .draw-panel-header strong {
+  color: #eee;
+}
+
+[data-theme="dark"] .draw-clear-btn {
+  background: #1a1a3a;
+  border-color: #3a3a5a;
+  color: #aaa;
+}
+
+[data-theme="dark"] .draw-clear-btn:hover {
+  border-color: #e63946;
+  color: #e63946;
+  background: #2a1a1a;
+}
+
+[data-theme="dark"] .draw-info {
+  color: #9a9ab0;
+}
+
+[data-theme="dark"] .draw-feature-row {
+  border-color: #2a2a4a;
+}
+
+[data-theme="dark"] .toolbar-btn.active {
+  background: #1a2a4a;
+  border-color: #4285f4;
+  color: #7baff4;
+}


### PR DESCRIPTION
## Summary
This PR adds drawing capabilities to the map application using Mapbox GL Draw, allowing users to create and manage geometric shapes (points, lines, and polygons) with a dedicated panel for tracking drawn features.

## Key Changes
- **Drawing Tools Integration**: Integrated `@mapbox/mapbox-gl-draw` library to enable point, line, and polygon drawing on the map
- **Draw Toggle Button**: Added a "Draw" button in the toolbar to toggle drawing mode on/off with active state styling
- **Draw Panel UI**: Created a new panel below the map that displays:
  - List of all drawn features with their properties (coordinates for points, vertex counts for polygons/lines)
  - "Clear All" button to remove all drawn features at once
  - Contextual messaging when no features are drawn
- **Feature Tracking**: Implemented `updateDrawInfo()` function that automatically updates the panel whenever features are created, modified, or deleted
- **Dark Mode Support**: Added comprehensive dark theme styling for all new draw-related components
- **Styling**: Added 95 lines of CSS with proper spacing, colors, hover states, and responsive design

## Implementation Details
- Draw panel is hidden by default and toggles visibility with the Draw button
- The draw control is dynamically added/removed from the map based on toggle state
- Feature information is formatted with readable coordinates (5 decimal places) and vertex counts
- All new UI elements follow existing design patterns with consistent spacing and typography
- Dark theme colors match the existing application theme palette

https://claude.ai/code/session_01UKFF89LVqpy1V9bxpNA51s