### PR TITLE
Add vector contour lines overlay via maplibre-contour

### DIFF
--- a/apps/scaled-template/app.js
+++ b/apps/scaled-template/app.js
@@ -4,6 +4,7 @@ let filteredFeatures = [];
 let currentPopup;
 let draw;
 let measuring = false;
+let contourDemSource;
 
 // --- Info panel toggle ---
 
@@ -319,6 +320,64 @@ function initTopoOverlay() {
     paint: { "raster-opacity": 0.9 }
   }, firstLabelLayer ? firstLabelLayer.id : undefined);
 
+  // Vector contour lines via maplibre-contour (generated client-side from DEM)
+  var contourLayerIds = [];
+  if (contourDemSource) {
+    map.addSource("contour-source", {
+      type: "vector",
+      tiles: [contourDemSource.contourProtocolUrl({
+        multiplier: 3.28084, // meters -> feet
+        overzoom: 1,
+        thresholds: {
+          11: [200, 1000],
+          12: [100, 500],
+          13: [100, 500],
+          14: [50, 200],
+          15: [20, 100]
+        },
+        elevationKey: "ele",
+        levelKey: "level",
+        contourLayer: "contours"
+      })],
+      maxzoom: 15
+    });
+
+    map.addLayer({
+      id: "contour-lines",
+      type: "line",
+      source: "contour-source",
+      "source-layer": "contours",
+      layout: { visibility: "none" },
+      paint: {
+        "line-color": "#6b4423",
+        "line-opacity": 0.5,
+        "line-width": ["match", ["get", "level"], 1, 1, 0.5]
+      }
+    });
+
+    map.addLayer({
+      id: "contour-labels",
+      type: "symbol",
+      source: "contour-source",
+      "source-layer": "contours",
+      filter: [">", ["get", "level"], 0],
+      layout: {
+        visibility: "none",
+        "symbol-placement": "line",
+        "text-size": 10,
+        "text-field": ["concat", ["number-format", ["get", "ele"], {}], "'"],
+        "text-font": ["Noto Sans Regular"]
+      },
+      paint: {
+        "text-color": "#6b4423",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    });
+
+    contourLayerIds = ["contour-lines", "contour-labels"];
+  }
+
   map.addControl({
     onAdd() {
       this._container = document.createElement("div");
@@ -331,12 +390,18 @@ function initTopoOverlay() {
       checkbox.addEventListener("change", function () {
         if (!this.checked) {
           map.setLayoutProperty("usgs-topo-layer", "visibility", "none");
+          contourLayerIds.forEach(function (id) {
+            if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "none");
+          });
           // Restore default terrain exaggeration
           map.setTerrain({ source: "terrain-dem", exaggeration: 1 });
           return;
         }
-        // Show topo raster and bump exaggeration
+        // Show topo raster, contour lines, and bump exaggeration
         map.setLayoutProperty("usgs-topo-layer", "visibility", "visible");
+        contourLayerIds.forEach(function (id) {
+          if (map.getLayer(id)) map.setLayoutProperty(id, "visibility", "visible");
+        });
         map.setTerrain({ source: "terrain-dem", exaggeration: 2 });
       });
 
@@ -525,6 +590,18 @@ async function init() {
       a.innerHTML = svgMap[s.platform] || "";
       socialContainer.appendChild(a);
     });
+  }
+
+  // Set up maplibre-contour DEM source (registers custom protocol) so the topo
+  // overlay can add vector contour tiles on demand.
+  if (window.mlcontour && !contourDemSource) {
+    contourDemSource = new mlcontour.DemSource({
+      url: "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png",
+      encoding: "terrarium",
+      maxzoom: 14,
+      worker: true
+    });
+    contourDemSource.setupMaplibre(maplibregl);
   }
 
   // Create map

--- a/apps/scaled-template/index.html
+++ b/apps/scaled-template/index.html
@@ -80,6 +80,7 @@
 
   <script src="https://unpkg.com/jspdf@2.5.2/dist/jspdf.umd.min.js"></script>
   <script src="https://unpkg.com/maplibre-gl@5/dist/maplibre-gl.js"></script>
+  <script src="https://unpkg.com/maplibre-contour@0.0.5/dist/index.min.js"></script>
   <script src="https://unpkg.com/terra-draw/dist/terra-draw.umd.js"></script>
   <script src="https://unpkg.com/terra-draw-maplibre-gl-adapter/dist/terra-draw-maplibre-gl-adapter.umd.js"></script>
 <script src="./config.js"></script>


### PR DESCRIPTION
## Summary
This PR adds vector contour line visualization to the topographic overlay, generated client-side from DEM data using the maplibre-contour library. Contour lines and elevation labels are now displayed alongside the USGS topographic raster when the topo overlay is enabled.

## Key Changes
- **Added maplibre-contour library**: Included the maplibre-contour script in index.html to enable client-side contour generation from DEM tiles
- **Initialized DEM source**: Set up a `DemSource` instance in the `init()` function that registers a custom protocol for serving contour tiles from Terrarium-encoded elevation data
- **Added contour layers**: Created two new map layers in `initTopoOverlay()`:
  - `contour-lines`: Line layer displaying elevation contours with variable width based on contour level
  - `contour-labels`: Symbol layer showing elevation values along contour lines
- **Synchronized visibility**: Updated the topo overlay checkbox to toggle both the raster layer and vector contour layers together, maintaining consistent visibility state
- **Configured zoom-dependent thresholds**: Set elevation thresholds that vary by zoom level (200-1000 ft at z11, down to 20-100 ft at z15) for appropriate contour density

## Implementation Details
- Contour lines use a brown color scheme (#6b4423) with 50% opacity to complement the topographic raster
- Major contours (level=1) are rendered with 1px width while minor contours use 0.5px for visual hierarchy
- Elevation labels are displayed in feet (converted from meters using 3.28084 multiplier) with white halos for readability
- The contour source is only initialized if the maplibre-contour library is available, providing graceful degradation

https://claude.ai/code/session_01TjkDyCqcm5YSzLTxCG1ZYf