### PR TITLE
Improve mobile map design on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,6 @@
   <main>
     <section class="map-hero">
       <div id="map" role="application" aria-label="3D map of Austin, Texas"></div>
-      <div class="hero-overlay">
-        <p class="eyebrow">Austin, Texas</p>
-        <ul class="city-facts">
-          <li><strong>Mayor:</strong> Kirk Watson</li>
-          <li><strong>Population:</strong> ~997,600</li>
-          <li><strong>Area:</strong> 320 sq miles (Land)</li>
-        </ul>
-      </div>
     </section>
 
   </main>

--- a/style.css
+++ b/style.css
@@ -152,34 +152,27 @@ main {
   position: relative;
   flex: 1;
   display: flex;
-  min-height: 70vh;
+  height: 560px;
   border-bottom: 1px solid var(--border);
   overflow: hidden;
 }
 
+.map-hero::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.12), transparent);
+  pointer-events: none;
+  z-index: 1;
+}
+
 #map {
   flex: 1;
-  min-height: 70vh;
+  height: 560px;
   width: 100%;
-}
-
-.hero-overlay {
-  position: absolute;
-  top: 12%;
-  left: 8%;
-  max-width: 520px;
-  background: rgba(255, 255, 255, 0.78);
-  backdrop-filter: blur(6px);
-  border-radius: 18px;
-  padding: 1.5rem 1.75rem;
-  box-shadow: 0 24px 50px rgba(18, 38, 64, 0.15);
-  text-align: left;
-}
-
-:root[data-theme='dark'] .hero-overlay {
-  background: rgba(22, 27, 35, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.6);
 }
 
 .eyebrow {
@@ -195,19 +188,6 @@ main {
   margin: 0 0 1.25rem;
   color: var(--muted);
   line-height: 1.6;
-}
-
-.city-facts {
-  list-style: disc;
-  padding-left: 1.25rem;
-  margin: 0;
-  display: grid;
-  gap: 0.65rem;
-  color: var(--text);
-}
-
-.city-facts strong {
-  color: var(--text);
 }
 
 .news-feed {
@@ -521,14 +501,7 @@ main {
 
   .map-hero,
   #map {
-    min-height: 65vh;
-  }
-
-  .hero-overlay {
-    position: static;
-    margin: -3rem 1rem 1rem;
-    max-width: none;
-    text-align: left;
+    height: 380px;
   }
 
   .cta-group {


### PR DESCRIPTION
- Remove mayor/city-facts overlay card that blocked the map on mobile
- Reduce map height from 70vh to 560px desktop / 380px mobile (fixed heights)
- Add subtle 6px top-shadow pseudo-element from citywide template pattern
- Remove orphaned .hero-overlay and .city-facts CSS rules

https://claude.ai/code/session_01JeiSdZezEhnPV98QDudneC