### PR TITLE
Add homepage report cards + wire Austin Chambers

### DIFF
--- a/apps/skills/staging-intake/SKILL.md
+++ b/apps/skills/staging-intake/SKILL.md
@@ -144,13 +144,31 @@ pointing to `/apps/citywide/<slug>/`, e.g.:
 
 (`page.js` listens for `.nav-link` clicks; `<a>` and `<button>` both work.)
 
+Also add a homepage **report card** entry by appending to
+`storymaps/reports.json` (create the file if it doesn't exist yet). Each entry
+drives one card in the homepage's `.report-cards` strip:
+
+```json
+{
+  "id": "<slug>",
+  "title": "<title>",
+  "eyebrow": "<eyebrow> · Report",
+  "blurb": "<one-sentence summary — same copy as the app's data-description works well>",
+  "href": "/storymaps/<slug>/report.html",
+  "accent": "<marker_color>"
+}
+```
+
+Keep the blurb ≤ ~110 characters so it fits in the card's two-line clamp. If
+front-matter doesn't give you a blurb, reuse the app's data-description.
+
 ### 6 — Commit and push
 
 Single commit on the working branch (`claude/review-staging-workflow-xfpEx`
 unless told otherwise):
 
 ```
-git add apps/citywide/<slug>/ storymaps/<slug>/ storymaps/index.json apps.html
+git add apps/citywide/<slug>/ storymaps/<slug>/ storymaps/index.json storymaps/reports.json apps.html
 git commit -m "Deploy <title> from staging (app + storymap + report)"
 git push -u origin claude/review-staging-workflow-xfpEx
 ```

--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
     <section class="storymap-nav-bar">
       <div id="storymap-nav" class="storymap-nav" role="group" aria-label="Story map selector"></div>
     </section>
+
+    <section class="report-cards" aria-label="Featured reports">
+      <div id="report-cards" class="report-cards-inner"></div>
+    </section>
   </main>
 
   <footer class="page-footer">
@@ -88,6 +92,47 @@
         .catch(() => {
           // If the config can't be fetched, hide the selector bar gracefully
           document.querySelector('.storymap-nav-bar')?.remove();
+        });
+    }());
+
+    // ── Featured report cards ──────────────────────────────────────
+    (function () {
+      const cards = document.getElementById('report-cards');
+      if (!cards) return;
+
+      fetch('/storymaps/reports.json')
+        .then(r => r.ok ? r.json() : [])
+        .then(items => {
+          if (!items || !items.length) {
+            document.querySelector('.report-cards')?.remove();
+            return;
+          }
+          items.forEach(item => {
+            const card = document.createElement('a');
+            card.className = 'report-card';
+            card.href = item.href;
+            if (item.accent) card.style.setProperty('--card-accent', item.accent);
+
+            const eyebrow = document.createElement('span');
+            eyebrow.className = 'report-card-eyebrow';
+            eyebrow.textContent = item.eyebrow || 'Report';
+
+            const title = document.createElement('h3');
+            title.className = 'report-card-title';
+            title.textContent = item.title || '';
+
+            const blurb = document.createElement('p');
+            blurb.className = 'report-card-blurb';
+            blurb.textContent = item.blurb || '';
+
+            card.appendChild(eyebrow);
+            card.appendChild(title);
+            card.appendChild(blurb);
+            cards.appendChild(card);
+          });
+        })
+        .catch(() => {
+          document.querySelector('.report-cards')?.remove();
         });
     }());
 

--- a/storymaps/reports.json
+++ b/storymaps/reports.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "austin-chambers",
+    "title": "Austin-Area Chambers of Commerce",
+    "eyebrow": "Austin Metro · Report",
+    "blurb": "Regional, affinity, and corridor chambers mapped across Greater Austin.",
+    "href": "/storymaps/austin-chambers/report.html",
+    "accent": "#6f4e37"
+  }
+]

--- a/style.css
+++ b/style.css
@@ -224,6 +224,80 @@ main {
   color: #fff;
 }
 
+/* ── Featured report cards ───────────────────────────────── */
+.report-cards {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px 12px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.report-cards::-webkit-scrollbar { display: none; }
+
+.report-cards-inner {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.report-card {
+  --card-accent: var(--accent);
+  flex: 0 0 280px;
+  max-width: 320px;
+  padding: 9px 13px 11px;
+  background: color-mix(in srgb, var(--surface) 94%, var(--card-accent) 6%);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--card-accent);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--text);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.report-card:hover,
+.report-card:focus-visible {
+  color: var(--text);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px var(--shadow);
+  border-color: var(--card-accent);
+  outline: none;
+}
+
+.report-card-eyebrow {
+  font-size: 0.66rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--card-accent);
+}
+
+.report-card-title {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  font-family: 'Poppins', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: var(--text);
+  font-weight: 700;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.report-card-blurb {
+  margin: 0;
+  font-size: 0.81rem;
+  line-height: 1.35;
+  color: var(--muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .eyebrow {
   margin: 0;
   letter-spacing: 0.12em;


### PR DESCRIPTION
## Summary
- Adds a compact `.report-cards` strip to `index.html` between the storymap selector and the footer, driven by a new `storymaps/reports.json` manifest. First card points at the Austin Chambers report.
- Cards are small by design (≤120px tall, 280px wide, two-line blurb clamp) so they slot into existing blank space without growing the main layout. Accent color + border come from the report's marker color.
- Extends the `staging-intake` skill to append a `reports.json` entry during step 5 (wire-up), alongside the existing `apps.html` + `storymaps/index.json` edits.

## Test plan
- [ ] `https://anatomy.city/` shows the "Austin-Area Chambers of Commerce" card below the storymap selector.
- [ ] Clicking the card opens `/storymaps/austin-chambers/report.html`.
- [ ] Card renders correctly in both light and dark themes (accent `#6f4e37`).
- [ ] No visible layout shift vs. main before the change on desktop.

https://claude.ai/code/session_01K9eZyZwxJWeQmW9A3SQR8b