### PR TITLE
Drop home card; add City Anatomy text link at top of report

### DIFF
--- a/scripts/build-report.py
+++ b/scripts/build-report.py
@@ -196,7 +196,21 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Related-content nav (three link cards at the top of the report) */
+/* Site link at the very top — recognizable hyperlink, classic blue */
+.site-link {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  margin: 0 0 24px;
+}
+.site-link a {
+  color: #1a6cdb;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-weight: 500;
+}
+.site-link a:hover { color: #0a4fa8; }
+
+/* Related-content nav (link cards at the top of the report) */
 .report-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 28px; }
 .report-nav a {
   flex: 1 1 160px;
@@ -240,6 +254,7 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
   a { color: var(--ink); text-decoration: none; }
   .footnotes { page-break-before: always; }
   .report-nav { display: none !important; }
+  .site-link { display: none !important; }
 }
 """
 
@@ -253,6 +268,7 @@ HTML_TMPL = """<!DOCTYPE html>
 </head>
 <body>
 <article class="report">
+  {site_link_html}
   <header class="report-header">
     {eyebrow_html}
     <h1 class="title">{title_esc}</h1>
@@ -267,15 +283,13 @@ HTML_TMPL = """<!DOCTYPE html>
 """
 
 
-def _nav_html(app_url: str, storymap_url: str, home_url: str) -> str:
-    """Render the three-link nav that sits above the cover. Hidden in print CSS."""
+def _nav_html(app_url: str, storymap_url: str) -> str:
+    """Render the two-card nav that sits above the cover. Hidden in print CSS."""
     links: list[tuple[str, str, str]] = []
     if app_url:
         links.append(("Explore", "Interactive map →", app_url))
     if storymap_url:
         links.append(("Watch", "Story map →", storymap_url))
-    if home_url:
-        links.append(("Home", "City Anatomy →", home_url))
 
     if not links:
         return ""
@@ -287,6 +301,17 @@ def _nav_html(app_url: str, storymap_url: str, home_url: str) -> str:
         for eb, lbl, href in links
     )
     return f'<nav class="report-nav" aria-label="Related content">{items}</nav>'
+
+
+def _site_link_html(home_url: str, label: str = "City Anatomy") -> str:
+    """Render the small "City Anatomy" hyperlink at the very top. Hidden in print."""
+    if not home_url:
+        return ""
+    return (
+        f'<p class="site-link">'
+        f'<a href="{html.escape(home_url)}">{html.escape(label)}</a>'
+        f'</p>'
+    )
 
 
 def build(md_path: Path, out_path: Path, title: str, subtitle: str = "",
@@ -315,12 +340,14 @@ def build(md_path: Path, out_path: Path, title: str, subtitle: str = "",
 
     eyebrow_html = f'<p class="eyebrow">{html.escape(eyebrow)}</p>' if eyebrow else ""
     subtitle_html = f'<p class="subtitle">{html.escape(subtitle)}</p>' if subtitle else ""
-    nav_html = _nav_html(app_url, storymap_url, home_url)
+    nav_html = _nav_html(app_url, storymap_url)
+    site_link_html = _site_link_html(home_url)
 
     out = HTML_TMPL.format(
         title_esc=html.escape(title),
         eyebrow_html=eyebrow_html,
         subtitle_html=subtitle_html,
+        site_link_html=site_link_html,
         nav_html=nav_html,
         cover_html=cover_html,
         body_html=body_html,

--- a/storymaps/austin-chambers/report.html
+++ b/storymaps/austin-chambers/report.html
@@ -53,7 +53,21 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Related-content nav (three link cards at the top of the report) */
+/* Site link at the very top — recognizable hyperlink, classic blue */
+.site-link {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  margin: 0 0 24px;
+}
+.site-link a {
+  color: #1a6cdb;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-weight: 500;
+}
+.site-link a:hover { color: #0a4fa8; }
+
+/* Related-content nav (link cards at the top of the report) */
 .report-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 28px; }
 .report-nav a {
   flex: 1 1 160px;
@@ -97,17 +111,19 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
   a { color: var(--ink); text-decoration: none; }
   .footnotes { page-break-before: always; }
   .report-nav { display: none !important; }
+  .site-link { display: none !important; }
 }
 </style>
 </head>
 <body>
 <article class="report">
+  <p class="site-link"><a href="/">City Anatomy</a></p>
   <header class="report-header">
     <p class="eyebrow">Austin Metro</p>
     <h1 class="title">Austin-Area Chambers of Commerce</h1>
     <p class="subtitle">Regional and affinity chambers across Greater Austin</p>
   </header>
-  <nav class="report-nav" aria-label="Related content"><a href="/apps/citywide/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Explore</span><span class="rn-label">Interactive map →</span></a><a href="/storymaps/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Watch</span><span class="rn-label">Story map →</span></a><a href="/" target="_blank" rel="noopener"><span class="rn-eyebrow">Home</span><span class="rn-label">City Anatomy →</span></a></nav>
+  <nav class="report-nav" aria-label="Related content"><a href="/apps/citywide/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Explore</span><span class="rn-label">Interactive map →</span></a><a href="/storymaps/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Watch</span><span class="rn-label">Story map →</span></a></nav>
   
   <h2 id="executive-summary">Executive Summary</h2>
 <p>The Austin metropolitan area is served by a diverse network of chambers of commerce that support businesses by geography (city or corridor) and by affinity (ethnicity, age, or LGBTQ+ identity).<sup>1</sup><sup>2</sup> This report profiles major chambers in and around Austin, highlighting their locations, focus areas, and roles in regional economic and community development.<sup>3</sup></p>


### PR DESCRIPTION
## Summary
- Replaces the third "Home" nav card with a small classic-blue underlined "City Anatomy" hyperlink at the very top of `report.html`, above the title.
- Report nav now shows two cards on one line: **Explore → Interactive map** and **Watch → Story map**.
- Site link uses the same `@media print` hide rule, so the PDF output stays unchanged.

## Test plan
- [ ] `https://anatomy.city/storymaps/austin-chambers/report.html` shows "City Anatomy" link at the very top, then title, then two cards.
- [ ] Clicking "City Anatomy" goes to `/`.
- [ ] Both cards open in new tabs.
- [ ] Save-as-PDF omits the link and the cards.

https://claude.ai/code/session_01K9eZyZwxJWeQmW9A3SQR8b