### PR TITLE
Enlarge City Anatomy link to title-scale and move below header

### DIFF
--- a/scripts/build-report.py
+++ b/scripts/build-report.py
@@ -196,17 +196,18 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Site link at the very top — recognizable hyperlink, classic blue */
+/* Site link — sits a couple lines under the title, typographically paired with it */
 .site-link {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px;
-  margin: 0 0 24px;
+  margin: 28px 0 32px;
+  font-family: Georgia, "Iowan Old Style", "Source Serif Pro", serif;
+  font-size: 36px;
+  line-height: 1.15;
+  font-weight: 700;
 }
 .site-link a {
   color: #1a6cdb;
   text-decoration: underline;
-  text-underline-offset: 3px;
-  font-weight: 500;
+  text-underline-offset: 4px;
 }
 .site-link a:hover { color: #0a4fa8; }
 
@@ -268,12 +269,12 @@ HTML_TMPL = """<!DOCTYPE html>
 </head>
 <body>
 <article class="report">
-  {site_link_html}
   <header class="report-header">
     {eyebrow_html}
     <h1 class="title">{title_esc}</h1>
     {subtitle_html}
   </header>
+  {site_link_html}
   {nav_html}
   {cover_html}
   {body_html}

--- a/storymaps/austin-chambers/report.html
+++ b/storymaps/austin-chambers/report.html
@@ -53,17 +53,18 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Site link at the very top — recognizable hyperlink, classic blue */
+/* Site link — sits a couple lines under the title, typographically paired with it */
 .site-link {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px;
-  margin: 0 0 24px;
+  margin: 28px 0 32px;
+  font-family: Georgia, "Iowan Old Style", "Source Serif Pro", serif;
+  font-size: 36px;
+  line-height: 1.15;
+  font-weight: 700;
 }
 .site-link a {
   color: #1a6cdb;
   text-decoration: underline;
-  text-underline-offset: 3px;
-  font-weight: 500;
+  text-underline-offset: 4px;
 }
 .site-link a:hover { color: #0a4fa8; }
 
@@ -117,12 +118,12 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 </head>
 <body>
 <article class="report">
-  <p class="site-link"><a href="/">City Anatomy</a></p>
   <header class="report-header">
     <p class="eyebrow">Austin Metro</p>
     <h1 class="title">Austin-Area Chambers of Commerce</h1>
     <p class="subtitle">Regional and affinity chambers across Greater Austin</p>
   </header>
+  <p class="site-link"><a href="/">City Anatomy</a></p>
   <nav class="report-nav" aria-label="Related content"><a href="/apps/citywide/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Explore</span><span class="rn-label">Interactive map →</span></a><a href="/storymaps/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Watch</span><span class="rn-label">Story map →</span></a></nav>
   
   <h2 id="executive-summary">Executive Summary</h2>


### PR DESCRIPTION
## Summary
- Moves the "City Anatomy" site link from above the header to a couple lines beneath the title block.
- Restyles it to match the title: Georgia serif, 36px, weight 700, line-height 1.15.
- Keeps classic blue + underline so it still reads as a hyperlink.

## Test plan
- [ ] `https://anatomy.city/storymaps/austin-chambers/report.html` shows the big "City Anatomy" link just under the title/subtitle block and before the two cards.
- [ ] Link renders at title size and is visibly underlined + blue.
- [ ] Save-as-PDF still omits the link.

https://claude.ai/code/session_01K9eZyZwxJWeQmW9A3SQR8b