### PR TITLE
Social icons + City Anatomy link in report header; larger nav cards

### DIFF
--- a/scripts/build-report.py
+++ b/scripts/build-report.py
@@ -196,13 +196,38 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Site link — sits a couple lines under the title, typographically paired with it */
+/* Site bar at the top of the header: social icons on top, homepage link below */
+.site-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 28px;
+}
+.site-bar .social-icons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+.site-bar .social-icons a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px; height: 28px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.site-bar .social-icons a:hover { color: var(--accent); }
+.site-bar .social-icons svg { width: 20px; height: 20px; }
+
+/* Site link — title-scaled hyperlink sitting right under the icons */
 .site-link {
-  margin: 28px 0 32px;
+  margin: 0;
   font-family: Georgia, "Iowan Old Style", "Source Serif Pro", serif;
   font-size: 36px;
   line-height: 1.15;
   font-weight: 700;
+  text-align: center;
 }
 .site-link a {
   color: #1a6cdb;
@@ -212,20 +237,20 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .site-link a:hover { color: #0a4fa8; }
 
 /* Related-content nav (link cards at the top of the report) */
-.report-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 28px; }
+.report-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 0 0 28px; }
 .report-nav a {
-  flex: 1 1 160px;
-  min-width: 140px;
-  padding: 9px 13px 11px;
+  flex: 1 1 180px;
+  min-width: 160px;
+  padding: 12px 16px 14px;
   background: color-mix(in srgb, var(--bg) 85%, var(--accent) 6%);
   border: 1px solid var(--rule);
-  border-left: 3px solid var(--accent);
-  border-radius: 8px;
+  border-left: 4px solid var(--accent);
+  border-radius: 10px;
   text-decoration: none;
   color: var(--ink);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .report-nav a:hover, .report-nav a:focus-visible {
@@ -237,12 +262,12 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 }
 .report-nav .rn-eyebrow {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+  font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase;
   color: var(--accent); font-weight: 700;
 }
 .report-nav .rn-label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 13px; font-weight: 600; color: var(--ink);
+  font-size: 17px; font-weight: 600; color: var(--ink);
 }
 
 /* Print-specific (Save as PDF) */
@@ -255,7 +280,7 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
   a { color: var(--ink); text-decoration: none; }
   .footnotes { page-break-before: always; }
   .report-nav { display: none !important; }
-  .site-link { display: none !important; }
+  .site-bar { display: none !important; }
 }
 """
 
@@ -270,11 +295,11 @@ HTML_TMPL = """<!DOCTYPE html>
 <body>
 <article class="report">
   <header class="report-header">
+    {site_bar_html}
     {eyebrow_html}
     <h1 class="title">{title_esc}</h1>
     {subtitle_html}
   </header>
-  {site_link_html}
   {nav_html}
   {cover_html}
   {body_html}
@@ -282,6 +307,21 @@ HTML_TMPL = """<!DOCTYPE html>
 </body>
 </html>
 """
+
+
+# Matches the icons rendered in the site footer on every other page.
+# Kept inline so report.html stays self-contained (no external asset fetch).
+SOCIAL_ICONS_HTML = (
+    '<div class="social-icons">'
+    '<a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>'
+    '<a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>'
+    '<a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>'
+    '<a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>'
+    '<a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>'
+    '<a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>'
+    '<a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>'
+    '</div>'
+)
 
 
 def _nav_html(app_url: str, storymap_url: str) -> str:
@@ -304,15 +344,16 @@ def _nav_html(app_url: str, storymap_url: str) -> str:
     return f'<nav class="report-nav" aria-label="Related content">{items}</nav>'
 
 
-def _site_link_html(home_url: str, label: str = "City Anatomy") -> str:
-    """Render the small "City Anatomy" hyperlink at the very top. Hidden in print."""
+def _site_bar_html(home_url: str, label: str = "City Anatomy") -> str:
+    """Two-line bar at the top of the header: social icons, then homepage link."""
     if not home_url:
         return ""
-    return (
+    link_row = (
         f'<p class="site-link">'
         f'<a href="{html.escape(home_url)}">{html.escape(label)}</a>'
         f'</p>'
     )
+    return f'<div class="site-bar">{SOCIAL_ICONS_HTML}{link_row}</div>'
 
 
 def build(md_path: Path, out_path: Path, title: str, subtitle: str = "",
@@ -342,13 +383,13 @@ def build(md_path: Path, out_path: Path, title: str, subtitle: str = "",
     eyebrow_html = f'<p class="eyebrow">{html.escape(eyebrow)}</p>' if eyebrow else ""
     subtitle_html = f'<p class="subtitle">{html.escape(subtitle)}</p>' if subtitle else ""
     nav_html = _nav_html(app_url, storymap_url)
-    site_link_html = _site_link_html(home_url)
+    site_bar_html = _site_bar_html(home_url)
 
     out = HTML_TMPL.format(
         title_esc=html.escape(title),
         eyebrow_html=eyebrow_html,
         subtitle_html=subtitle_html,
-        site_link_html=site_link_html,
+        site_bar_html=site_bar_html,
         nav_html=nav_html,
         cover_html=cover_html,
         body_html=body_html,

--- a/storymaps/austin-chambers/report.html
+++ b/storymaps/austin-chambers/report.html
@@ -53,13 +53,38 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .footnotes li { margin-bottom: 6px; }
 .fn-back { margin-left: 4px; text-decoration: none; }
 
-/* Site link — sits a couple lines under the title, typographically paired with it */
+/* Site bar at the top of the header: social icons on top, homepage link below */
+.site-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 28px;
+}
+.site-bar .social-icons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+.site-bar .social-icons a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px; height: 28px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.site-bar .social-icons a:hover { color: var(--accent); }
+.site-bar .social-icons svg { width: 20px; height: 20px; }
+
+/* Site link — title-scaled hyperlink sitting right under the icons */
 .site-link {
-  margin: 28px 0 32px;
+  margin: 0;
   font-family: Georgia, "Iowan Old Style", "Source Serif Pro", serif;
   font-size: 36px;
   line-height: 1.15;
   font-weight: 700;
+  text-align: center;
 }
 .site-link a {
   color: #1a6cdb;
@@ -69,20 +94,20 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 .site-link a:hover { color: #0a4fa8; }
 
 /* Related-content nav (link cards at the top of the report) */
-.report-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 28px; }
+.report-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 0 0 28px; }
 .report-nav a {
-  flex: 1 1 160px;
-  min-width: 140px;
-  padding: 9px 13px 11px;
+  flex: 1 1 180px;
+  min-width: 160px;
+  padding: 12px 16px 14px;
   background: color-mix(in srgb, var(--bg) 85%, var(--accent) 6%);
   border: 1px solid var(--rule);
-  border-left: 3px solid var(--accent);
-  border-radius: 8px;
+  border-left: 4px solid var(--accent);
+  border-radius: 10px;
   text-decoration: none;
   color: var(--ink);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .report-nav a:hover, .report-nav a:focus-visible {
@@ -94,12 +119,12 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
 }
 .report-nav .rn-eyebrow {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+  font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase;
   color: var(--accent); font-weight: 700;
 }
 .report-nav .rn-label {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 13px; font-weight: 600; color: var(--ink);
+  font-size: 17px; font-weight: 600; color: var(--ink);
 }
 
 /* Print-specific (Save as PDF) */
@@ -112,18 +137,18 @@ sup.fn-ref a, sup.footnote-ref a { color: var(--accent); text-decoration: none; 
   a { color: var(--ink); text-decoration: none; }
   .footnotes { page-break-before: always; }
   .report-nav { display: none !important; }
-  .site-link { display: none !important; }
+  .site-bar { display: none !important; }
 }
 </style>
 </head>
 <body>
 <article class="report">
   <header class="report-header">
+    <div class="site-bar"><div class="social-icons"><a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a><a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a><a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a><a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a><a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a><a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a><a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a></div><p class="site-link"><a href="/">City Anatomy</a></p></div>
     <p class="eyebrow">Austin Metro</p>
     <h1 class="title">Austin-Area Chambers of Commerce</h1>
     <p class="subtitle">Regional and affinity chambers across Greater Austin</p>
   </header>
-  <p class="site-link"><a href="/">City Anatomy</a></p>
   <nav class="report-nav" aria-label="Related content"><a href="/apps/citywide/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Explore</span><span class="rn-label">Interactive map →</span></a><a href="/storymaps/austin-chambers/" target="_blank" rel="noopener"><span class="rn-eyebrow">Watch</span><span class="rn-label">Story map →</span></a></nav>
   
   <h2 id="executive-summary">Executive Summary</h2>


### PR DESCRIPTION
## Summary
- Moves the "City Anatomy" link back into the report header. Header now has two preamble rows above the title:
  1. Row one: the seven social icons that appear in the site footer everywhere else (YouTube, X, Facebook, Instagram, Reddit, Patreon, Discord). Placeholder `href="#"` — user will wire these up manually later.
  2. Row two: the title-scaled "City Anatomy" hyperlink (Georgia 36px weight 700, classic blue + underline).
- Bumps the two nav cards for readability: eyebrow 10→12px, label 13→17px, card padding nudged up.
- `@media print` hides the whole site bar and nav cards so Save-as-PDF output is unchanged.

## Test plan
- [ ] `https://anatomy.city/storymaps/austin-chambers/report.html` shows icons row, then big City Anatomy link, then the title block.
- [ ] Nav card text is noticeably larger and easier to read.
- [ ] Save-as-PDF omits the icons, the City Anatomy link, and the nav cards.

https://claude.ai/code/session_01K9eZyZwxJWeQmW9A3SQR8b