### PR TITLE
Add /tourmaps/ — geofence-triggered walking tour experience

### DIFF
--- a/tourmaps/index.json
+++ b/tourmaps/index.json
@@ -1,0 +1,3 @@
+[
+  { "id": "tejano-trail", "label": "Tejano Trail (East Austin)" }
+]

--- a/tourmaps/reports.json
+++ b/tourmaps/reports.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "tejano-trail",
+    "category": "Walking Tours",
+    "title": "Tejano Trail — East Austin",
+    "eyebrow": "East Austin · Walking tour",
+    "blurb": "A geofenced historical walk through East Austin's Tejano community. Popups trigger as you enter each point of interest.",
+    "href": "/tourmaps/tejano-trail/",
+    "accent": "#b4531a"
+  }
+]

--- a/tourmaps/tejano-trail/data/stops.geojson
+++ b/tourmaps/tejano-trail/data/stops.geojson
@@ -1,0 +1,4 @@
+{
+  "type": "FeatureCollection",
+  "features": []
+}

--- a/tourmaps/tejano-trail/engine.js
+++ b/tourmaps/tejano-trail/engine.js
@@ -1,0 +1,418 @@
+// TourEngine — drives the /tourmaps/ geofence-triggered walking-tour experience.
+// All content, stop geofences, layers, and popup content come from tour.json.
+// Popups fire when the user's geolocation crosses into a stop's radius, or when
+// the user clicks a stop in the side panel / drags the simulate marker.
+
+class TourEngine {
+  constructor(map) {
+    this.map = map;
+    this.tour = null;
+    this.stops = [];
+    this.visited = new Set();
+
+    this.popup = null;
+    this.ytPlayer = null;
+    this.ytReady = false;
+    this._ytAPIPromise = null;
+    this._ytPollInterval = null;
+
+    this._watchId = null;
+    this._lastCheck = null;         // { lng, lat } of last geofence check
+    this._hereMarker = null;
+    this._simulate = false;
+    this._simMarker = null;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────
+
+  async start(url) {
+    const res = await fetch(url);
+    this.tour = await res.json();
+    this.stops = this.tour.stops ?? [];
+
+    const ic = this.tour.initialCamera;
+    if (ic) {
+      this.map.jumpTo({
+        center: ic.center,
+        zoom: ic.zoom ?? 15,
+        pitch: ic.pitch ?? 0,
+        bearing: ic.bearing ?? 0,
+      });
+    }
+
+    if (Array.isArray(this.tour.maxBounds) && this.tour.maxBounds.length === 2) {
+      this.map.setMaxBounds(this.tour.maxBounds);
+    }
+
+    this._initStopsSource();
+    this._initLayers();
+    this._emit('tour-loaded', { tour: this.tour });
+  }
+
+  requestGeolocation() {
+    if (!('geolocation' in navigator)) {
+      this._emit('geolocation-unavailable', {});
+      return;
+    }
+    const opts = {
+      enableHighAccuracy: this.tour?.geofence?.enableHighAccuracy !== false,
+      maximumAge: 5000,
+      timeout: 20000,
+    };
+    this._watchId = navigator.geolocation.watchPosition(
+      pos => this._onPosition(pos),
+      err => this._onPositionError(err),
+      opts
+    );
+  }
+
+  stopGeolocation() {
+    if (this._watchId != null) {
+      navigator.geolocation.clearWatch(this._watchId);
+      this._watchId = null;
+    }
+  }
+
+  enableSimulateMode(startLngLat) {
+    if (this._simulate) return;
+    this._simulate = true;
+    this.stopGeolocation();
+
+    const el = document.createElement('div');
+    el.className = 'tm-simulate-marker';
+    el.innerHTML = '<span class="tm-simulate-dot"></span><span class="tm-simulate-label">SIM</span>';
+
+    const start = startLngLat ?? this.tour?.initialCamera?.center ?? this.map.getCenter().toArray();
+    this._simMarker = new maplibregl.Marker({ element: el, draggable: true })
+      .setLngLat(start)
+      .addTo(this.map);
+
+    this._simMarker.on('dragend', () => {
+      const { lng, lat } = this._simMarker.getLngLat();
+      this._setSimulatedPosition(lng, lat);
+    });
+
+    this._setSimulatedPosition(start[0], start[1]);
+    this._emit('simulate-enabled', {});
+  }
+
+  triggerStopById(id, source = 'click') {
+    const stop = this.stops.find(s => s.id === id);
+    if (stop) this._triggerStop(stop, source);
+  }
+
+  recenter() {
+    const pos = this._lastCheck;
+    if (!pos) return;
+    this.map.easeTo({ center: [pos.lng, pos.lat], duration: 600 });
+  }
+
+  isVisited(id) {
+    return this.visited.has(id);
+  }
+
+  // ── Geolocation handlers ────────────────────────────────────────
+
+  _onPosition(pos) {
+    const { latitude: lat, longitude: lng, accuracy } = pos.coords;
+    this._updateHereMarker(lng, lat, accuracy);
+
+    const minMove = this.tour?.geofence?.minMoveMeters ?? 5;
+    if (this._lastCheck) {
+      const moved = haversineMeters(this._lastCheck.lng, this._lastCheck.lat, lng, lat);
+      if (moved < minMove) return;
+    }
+    this._lastCheck = { lng, lat };
+    this._checkGeofences(lng, lat, 'gps');
+  }
+
+  _onPositionError(err) {
+    console.warn('TourEngine: geolocation error', err.message);
+    this._emit('geolocation-denied', { error: err.message, code: err.code });
+  }
+
+  _setSimulatedPosition(lng, lat) {
+    this._lastCheck = { lng, lat };
+    this._updateHereMarker(lng, lat, null);
+    this._checkGeofences(lng, lat, 'simulate');
+  }
+
+  _updateHereMarker(lng, lat, accuracy) {
+    if (this._simulate) return; // SIM marker is the "here" marker in simulate mode
+    if (!this._hereMarker) {
+      const el = document.createElement('div');
+      el.className = 'tm-here-marker';
+      el.innerHTML = '<span class="tm-here-pulse"></span><span class="tm-here-dot"></span>';
+      this._hereMarker = new maplibregl.Marker({ element: el })
+        .setLngLat([lng, lat])
+        .addTo(this.map);
+    } else {
+      this._hereMarker.setLngLat([lng, lat]);
+    }
+  }
+
+  _checkGeofences(lng, lat, source) {
+    const defaultRadius = this.tour?.geofence?.defaultRadiusMeters ?? 40;
+    const triggerOnce = this.tour?.geofence?.triggerOnce !== false;
+
+    for (const stop of this.stops) {
+      if (!stop.geofence?.center) continue;
+      const radius = stop.geofence.radiusMeters ?? defaultRadius;
+      const [sLng, sLat] = stop.geofence.center;
+      const d = haversineMeters(lng, lat, sLng, sLat);
+      if (d <= radius) {
+        if (triggerOnce && this.visited.has(stop.id)) continue;
+        this._triggerStop(stop, source);
+      }
+    }
+  }
+
+  // ── Stop trigger ────────────────────────────────────────────────
+
+  _triggerStop(stop, source) {
+    // Clean up any previous popup/video
+    if (this.popup) { this.popup.remove(); this.popup = null; }
+    this._clearYTPoll();
+    if (this.ytPlayer) { try { this.ytPlayer.stopVideo(); } catch (e) {} }
+
+    const center = stop.geofence?.center ?? stop.popup?.lngLat;
+    if (center) {
+      this.map.easeTo({
+        center,
+        zoom: stop.camera?.zoom ?? this.map.getZoom(),
+        pitch: stop.camera?.pitch ?? this.map.getPitch(),
+        bearing: stop.camera?.bearing ?? this.map.getBearing(),
+        duration: 800,
+        padding: { top: 200, bottom: 0, left: 0, right: 0 },
+      });
+    }
+
+    this._showPopup(stop);
+
+    const wasVisited = this.visited.has(stop.id);
+    this.visited.add(stop.id);
+    this._setStopVisitedOnMap(stop.id);
+
+    this._emit('stop-entered', {
+      stop,
+      source,
+      firstVisit: !wasVisited,
+      visitedCount: this.visited.size,
+      totalStops: this.stops.length,
+    });
+  }
+
+  _setStopVisitedOnMap(id) {
+    // Drive the "visited" data-driven styling via feature-state
+    if (!this.map.getSource('tour-stops')) return;
+    this.map.setFeatureState(
+      { source: 'tour-stops', id },
+      { visited: true }
+    );
+  }
+
+  // ── Popup (copied from StoryEngine for visual parity) ───────────
+
+  async _showPopup(stop) {
+    const p = stop.popup;
+    if (!p) return;
+    const lngLat = p.lngLat ?? stop.geofence?.center;
+    if (!lngLat) return;
+
+    const token = Date.now();
+    const html = this._buildPopupHTML(p, token);
+
+    this.popup = new maplibregl.Popup({
+      closeButton: true,
+      closeOnClick: false,
+      anchor: p.anchor ?? 'bottom',
+      offset: p.offset ?? 12,
+      maxWidth: '320px',
+    })
+      .setLngLat(lngLat)
+      .setHTML(html)
+      .addTo(this.map);
+
+    if (p.youtube) {
+      try {
+        await Promise.race([
+          this._loadYouTubeAPI(),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('YT API timeout')), 6000)),
+        ]);
+        const placeholderId = `yt-player-${token}`;
+        await Promise.race([
+          this._createYTPlayer(placeholderId, p.youtube.videoId, p.youtube.startAt, p.youtube.mute),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('YT Player timeout')), 8000)),
+        ]);
+        if (p.youtube.stopAt != null) this._pollYTForStopAt(p.youtube.stopAt, token);
+      } catch (e) {
+        console.warn('TourEngine: YouTube failed.', e.message);
+      }
+    }
+  }
+
+  _buildPopupHTML(p, token) {
+    let html = '<div class="sm-popup">';
+
+    if (p.title || p.subtitle) {
+      html += '<div class="sm-popup-header">';
+      if (p.title) html += `<h3 class="sm-popup-title">${p.title}</h3>`;
+      if (p.subtitle) html += `<p class="sm-popup-subtitle">${p.subtitle}</p>`;
+      html += '</div>';
+    }
+
+    if (p.image?.src) {
+      html += '<figure class="sm-popup-figure">';
+      html += `<img src="${p.image.src}" alt="${p.image.alt ?? ''}" class="sm-popup-img" loading="lazy" />`;
+      if (p.image.caption) html += `<figcaption>${p.image.caption}</figcaption>`;
+      html += '</figure>';
+    }
+
+    if (p.youtube) {
+      html += `<div class="sm-popup-video-wrap"><div id="yt-player-${token}" class="sm-yt-placeholder"></div></div>`;
+    }
+
+    if (p.body) {
+      html += `<div class="sm-popup-body">${p.body}</div>`;
+    }
+
+    if (p.stats?.length) {
+      html += '<table class="sm-popup-stats">';
+      p.stats.forEach(({ label, value }) => {
+        html += `<tr><th>${label}</th><td>${value}</td></tr>`;
+      });
+      html += '</table>';
+    }
+
+    if (p.link?.href) {
+      html += `<a class="sm-popup-link" href="${p.link.href}" target="_blank" rel="noopener noreferrer">${p.link.text ?? 'View →'}</a>`;
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  // ── Layers ──────────────────────────────────────────────────────
+
+  _initStopsSource() {
+    // Build a FeatureCollection from tour.json stops so authors only edit one file.
+    const features = this.stops
+      .filter(s => s.geofence?.center)
+      .map(s => ({
+        type: 'Feature',
+        id: s.id,
+        properties: {
+          id: s.id,
+          title: s.popup?.title ?? s.id,
+          subtitle: s.popup?.subtitle ?? '',
+          radiusMeters: s.geofence.radiusMeters ?? this.tour?.geofence?.defaultRadiusMeters ?? 40,
+        },
+        geometry: { type: 'Point', coordinates: s.geofence.center },
+      }));
+
+    if (!this.map.getSource('tour-stops')) {
+      this.map.addSource('tour-stops', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features },
+        promoteId: 'id',
+      });
+    }
+  }
+
+  _initLayers() {
+    const layers = this.tour.layers ?? [];
+    layers.forEach(layerDef => {
+      // Built-in virtual source: "tour-stops"
+      const useBuiltIn = layerDef.source === 'tour-stops';
+
+      if (!useBuiltIn && !this.map.getSource(layerDef.id)) {
+        this.map.addSource(layerDef.id, { type: 'geojson', data: layerDef.source });
+      }
+
+      const spec = {
+        id: layerDef.id,
+        type: layerDef.type,
+        source: useBuiltIn ? 'tour-stops' : layerDef.id,
+        paint: layerDef.paint ?? {},
+        layout: { visibility: 'visible', ...(layerDef.layout ?? {}) },
+      };
+      if (layerDef.sourceLayer) spec['source-layer'] = layerDef.sourceLayer;
+      if (layerDef.filter) spec.filter = layerDef.filter;
+
+      if (layerDef.insertBefore && this.map.getLayer(layerDef.insertBefore)) {
+        this.map.addLayer(spec, layerDef.insertBefore);
+      } else {
+        this.map.addLayer(spec);
+      }
+    });
+  }
+
+  // ── YouTube (copied from StoryEngine) ───────────────────────────
+
+  _loadYouTubeAPI() {
+    if (this.ytReady) return Promise.resolve();
+    if (this._ytAPIPromise) return this._ytAPIPromise;
+    this._ytAPIPromise = new Promise(resolve => {
+      window.onYouTubeIframeAPIReady = () => { this.ytReady = true; resolve(); };
+      const s = document.createElement('script');
+      s.src = 'https://www.youtube.com/iframe_api';
+      document.head.appendChild(s);
+    });
+    return this._ytAPIPromise;
+  }
+
+  _createYTPlayer(containerId, videoId, startAt, mute) {
+    if (this.ytPlayer) {
+      try { this.ytPlayer.destroy(); } catch (e) {}
+      this.ytPlayer = null;
+    }
+    return new Promise((resolve, reject) => {
+      const el = document.getElementById(containerId);
+      if (!el) { reject(new Error('YT placeholder not found')); return; }
+      this.ytPlayer = new YT.Player(containerId, {
+        videoId,
+        playerVars: {
+          autoplay: 1, start: startAt ?? 0, mute: mute !== false ? 1 : 0,
+          controls: 1, rel: 0, modestbranding: 1, playsinline: 1,
+        },
+        events: {
+          onReady: event => { event.target.playVideo(); resolve(event.target); },
+          onError: event => { reject(new Error(`YT player error: ${event.data}`)); },
+        },
+      });
+    });
+  }
+
+  _pollYTForStopAt(stopAt, token) {
+    this._clearYTPoll();
+    this._ytPollInterval = setInterval(() => {
+      if (!this.ytPlayer?.getCurrentTime) return;
+      try {
+        const t = this.ytPlayer.getCurrentTime();
+        if (t >= stopAt) { this._clearYTPoll(); }
+      } catch (e) { this._clearYTPoll(); }
+    }, 250);
+  }
+
+  _clearYTPoll() {
+    if (this._ytPollInterval) { clearInterval(this._ytPollInterval); this._ytPollInterval = null; }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────
+
+  _emit(name, detail) {
+    window.dispatchEvent(new CustomEvent(`tour:${name}`, { detail }));
+  }
+}
+
+// Great-circle distance in metres between two lng/lat pairs.
+function haversineMeters(aLng, aLat, bLng, bLat) {
+  const R = 6371000;
+  const toRad = d => d * Math.PI / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLng = toRad(bLng - aLng);
+  const s = Math.sin(dLat / 2) ** 2
+          + Math.cos(toRad(aLat)) * Math.cos(toRad(bLat))
+          * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(s));
+}

--- a/tourmaps/tejano-trail/index.html
+++ b/tourmaps/tejano-trail/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <base target="_blank" />
+  <title>Tejano Trail · East Austin Walking Tour</title>
+  <link href="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+
+  <div id="map"></div>
+
+  <div class="tm-brand-card">
+    <a href="/" class="tm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
+    <p id="tm-tour-name" class="tm-brand-title"></p>
+  </div>
+
+  <div id="tm-banner" class="tm-banner" hidden></div>
+
+  <div id="tm-progress" class="tm-progress-chip" aria-live="polite">0 / 0</div>
+
+  <button id="tm-stops-btn" class="tm-icon-btn" aria-label="Show stops list" title="Stops">
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M3 6h18v2H3zM3 11h18v2H3zM3 16h18v2H3z"/>
+    </svg>
+  </button>
+
+  <button id="tm-recenter" class="tm-icon-btn" aria-label="Recenter map on my location" title="Recenter">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M12 2v3M12 19v3M2 12h3M19 12h3"/>
+    </svg>
+  </button>
+
+  <aside id="tm-stops-panel" class="tm-stops-panel" aria-label="Tour stops">
+    <div class="tm-stops-panel-header">
+      <h2>Tejano Trail stops</h2>
+      <button id="tm-stops-close" class="tm-stops-close" aria-label="Close stops list">×</button>
+    </div>
+    <ul id="tm-stops-list" class="tm-stops-list"></ul>
+  </aside>
+
+  <div id="tm-permission" class="tm-permission-modal" role="dialog" aria-modal="true" aria-labelledby="tm-perm-title">
+    <div class="tm-permission-card">
+      <h2 id="tm-perm-title">Tejano Trail — East Austin</h2>
+      <p>A neighborhood-scale walking tour. Allow location and stops will pop up as you approach them. Or preview the route without sharing your location.</p>
+      <div class="tm-actions">
+        <button id="tm-preview"   class="tm-btn">Preview without GPS</button>
+        <button id="tm-allow-gps" class="tm-btn is-primary">Allow location</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.js"></script>
+  <script src="engine.js"></script>
+  <script src="ui.js"></script>
+  <script>
+    const map = new maplibregl.Map({
+      container: 'map',
+      style: 'https://tiles.openfreemap.org/styles/liberty',
+      center: [-97.728, 30.263],
+      zoom: 14.5,
+      pitch: 0,
+      bearing: 0,
+      antialias: true
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
+
+    const engine = new TourEngine(map);
+
+    map.on('load', () => {
+      const layers = map.getStyle().layers;
+      let labelLayerId;
+      for (const layer of layers) {
+        if (layer.type === 'symbol' && layer.layout['text-field']) {
+          labelLayerId = layer.id;
+          break;
+        }
+      }
+      map.addLayer({
+        id: '3d-buildings',
+        source: 'openmaptiles',
+        'source-layer': 'building',
+        filter: ['==', ['get', 'extrude'], 'true'],
+        type: 'fill-extrusion',
+        minzoom: 15,
+        paint: {
+          'fill-extrusion-color': '#aaa',
+          'fill-extrusion-height': ['get', 'render_height'],
+          'fill-extrusion-base': ['get', 'render_min_height'],
+          'fill-extrusion-opacity': 0.55
+        }
+      }, labelLayerId);
+
+      engine.start('tour.json').then(() => {
+        initTourUI(engine);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/tourmaps/tejano-trail/style.css
+++ b/tourmaps/tejano-trail/style.css
@@ -1,0 +1,510 @@
+/* ── CSS variables (light + dark) ─────────────────────────────── */
+:root {
+  --background: #f5f7fa;
+  --text: #1c1c28;
+  --accent: #b4531a;
+  --accent-light: #e8895a;
+  --surface: #ffffff;
+  --muted: #6f7780;
+  --border: #e1e6ee;
+  --shadow: rgba(15, 25, 45, 0.12);
+  --here: #1a73ff;
+  --sim: #b4531a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0e1117;
+    --text: #f5f7fa;
+    --accent: #e8895a;
+    --accent-light: #f4b48b;
+    --surface: #161b23;
+    --muted: #c0c7d1;
+    --border: #2a3040;
+    --shadow: rgba(0, 0, 0, 0.45);
+    --here: #6ea9ff;
+  }
+}
+
+/* ── Page reset — full-screen map ─────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  width: 100%; height: 100%;
+  overflow: hidden;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background: var(--background);
+}
+
+#map { position: fixed; inset: 0; width: 100%; height: 100%; }
+
+/* ── Brand card — top-right ─────────────────────────────────── */
+.tm-brand-card {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 20;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 10px 14px;
+  box-shadow: 0 8px 24px var(--shadow);
+  max-width: 240px;
+}
+.tm-brand-link {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-decoration: none;
+  margin-bottom: 4px;
+  transition: color 0.15s ease;
+}
+.tm-brand-link:hover { color: var(--accent); }
+.tm-brand-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+/* ── Permission modal ────────────────────────────────────────── */
+.tm-permission-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: color-mix(in srgb, var(--background) 70%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.tm-permission-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 22px 22px 18px;
+  max-width: 380px;
+  box-shadow: 0 20px 60px var(--shadow);
+  text-align: center;
+}
+.tm-permission-card h2 {
+  margin: 0 0 6px;
+  font-size: 1.15rem;
+  color: var(--text);
+}
+.tm-permission-card p {
+  margin: 0 0 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.tm-permission-card .tm-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.tm-btn {
+  flex: 1 1 120px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 14px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  background: var(--surface);
+  color: var(--text);
+}
+.tm-btn:hover { transform: translateY(-1px); border-color: var(--accent); }
+.tm-btn.is-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.tm-btn.is-primary:hover {
+  background: color-mix(in srgb, var(--accent) 85%, #000);
+  color: #fff;
+}
+
+/* ── Progress chip — bottom-center ───────────────────────────── */
+.tm-progress-chip {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text);
+  box-shadow: 0 4px 14px var(--shadow);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.tm-progress-chip::before {
+  content: '';
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+/* ── Round icon buttons (stops, recenter) ────────────────────── */
+.tm-icon-btn {
+  position: fixed;
+  z-index: 20;
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: var(--text);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 6px 16px var(--shadow);
+  padding: 0;
+  transition: transform 0.12s ease, border-color 0.15s ease;
+}
+.tm-icon-btn:hover {
+  transform: scale(1.05);
+  border-color: var(--accent);
+}
+.tm-icon-btn svg { width: 20px; height: 20px; }
+
+#tm-stops-btn    { bottom: 28px; left: 20px; }
+#tm-recenter     { bottom: 84px; left: 20px; }
+
+/* ── Stops side panel ─────────────────────────────────────────── */
+.tm-stops-panel {
+  position: fixed;
+  top: 0; bottom: 0;
+  left: 0;
+  z-index: 40;
+  width: min(360px, 85vw);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  box-shadow: 8px 0 24px var(--shadow);
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+.tm-stops-panel.is-open { transform: translateX(0); }
+
+.tm-stops-panel-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.tm-stops-panel-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+.tm-stops-close {
+  border: none;
+  background: transparent;
+  font-size: 1.3rem;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px 8px;
+}
+.tm-stops-close:hover { color: var(--text); }
+
+.tm-stops-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  overflow-y: auto;
+  flex: 1;
+}
+.tm-stop-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.tm-stop-item:hover {
+  background: color-mix(in srgb, var(--border) 35%, transparent);
+  border-left-color: var(--accent);
+}
+.tm-stop-index {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.tm-stop-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.tm-stop-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tm-stop-subtitle {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tm-stop-check {
+  opacity: 0;
+  color: var(--accent);
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+.tm-stop-item.is-visited .tm-stop-check { opacity: 1; }
+.tm-stop-item.is-visited .tm-stop-index {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── "You are here" marker ───────────────────────────────────── */
+.tm-here-marker {
+  position: relative;
+  width: 22px; height: 22px;
+  display: flex; align-items: center; justify-content: center;
+  pointer-events: none;
+}
+.tm-here-dot {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--here);
+  border: 3px solid #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  z-index: 2;
+}
+.tm-here-pulse {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--here);
+  opacity: 0.35;
+  animation: tm-pulse 1.6s ease-out infinite;
+}
+@keyframes tm-pulse {
+  0%   { transform: scale(0.5); opacity: 0.5; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+/* ── Simulate mode marker ────────────────────────────────────── */
+.tm-simulate-marker {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: grab;
+  pointer-events: auto;
+}
+.tm-simulate-marker:active { cursor: grabbing; }
+.tm-simulate-dot {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--sim);
+  border: 3px solid #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+}
+.tm-simulate-label {
+  margin-top: 4px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: #fff;
+  background: var(--sim);
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* ── Banner (simulate / denied hints) ────────────────────────── */
+.tm-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  background: var(--text);
+  color: var(--background);
+  padding: 8px 16px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 99px;
+  box-shadow: 0 6px 18px var(--shadow);
+  max-width: 80vw;
+  text-align: center;
+}
+
+/* ── MapLibre popup overrides (match storymaps) ─────────────── */
+.maplibregl-popup-content {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0;
+  box-shadow: 0 12px 32px var(--shadow);
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  min-width: 220px;
+  max-width: 320px;
+  overflow: hidden;
+}
+.maplibregl-popup-tip { border-top-color: var(--surface) !important; }
+.maplibregl-popup-close-button {
+  position: absolute;
+  top: 0; right: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+  padding: 8px 11px;
+  line-height: 1;
+  border-radius: 0 14px 0 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.maplibregl-popup-close-button:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--border) 40%, transparent);
+}
+
+/* ── Rich popup inner layout (same class names as storymaps) ── */
+.sm-popup { padding: 14px 16px 16px; }
+.sm-popup-header { margin-bottom: 10px; padding-right: 20px; }
+.sm-popup-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+.sm-popup-subtitle {
+  margin: 3px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.sm-popup-figure { margin: -14px -16px 12px; padding: 0; }
+.sm-popup-img {
+  width: 100%;
+  display: block;
+  max-height: 160px;
+  object-fit: cover;
+}
+.sm-popup-figure figcaption {
+  font-size: 0.72rem;
+  color: var(--muted);
+  padding: 4px 10px 2px;
+  text-align: right;
+}
+.sm-popup-video-wrap {
+  margin: 0 -16px 12px;
+  background: #000;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  position: relative;
+}
+.sm-yt-placeholder,
+.sm-popup-video-wrap iframe {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  border: none;
+  display: block;
+}
+.sm-popup-body {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.55;
+  margin-bottom: 10px;
+}
+.sm-popup-body p { margin: 0 0 6px; }
+.sm-popup-body p:last-child { margin-bottom: 0; }
+.sm-popup-stats {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  margin-bottom: 12px;
+  border-top: 1px solid var(--border);
+}
+.sm-popup-stats tr + tr td,
+.sm-popup-stats tr + tr th { border-top: 1px solid var(--border); }
+.sm-popup-stats th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 5px 8px 5px 0;
+  white-space: nowrap;
+  width: 42%;
+}
+.sm-popup-stats td {
+  text-align: right;
+  color: var(--text);
+  padding: 5px 0;
+  font-weight: 700;
+}
+.sm-popup-link {
+  display: block;
+  text-align: center;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.1s ease;
+  margin-top: 2px;
+}
+.sm-popup-link:hover {
+  background: color-mix(in srgb, var(--accent) 80%, #000);
+  transform: translateY(-1px);
+  color: #fff;
+}
+
+/* ── Mobile tweaks ───────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .tm-brand-card { top: 12px; right: 12px; padding: 8px 12px; max-width: 180px; }
+  .tm-brand-title { font-size: 0.85rem; }
+  .maplibregl-popup-content { max-width: 280px; }
+  #tm-stops-btn  { bottom: 24px; left: 14px; }
+  #tm-recenter   { bottom: 76px; left: 14px; }
+  .tm-progress-chip { bottom: 24px; padding: 6px 14px; font-size: 0.8rem; }
+}

--- a/tourmaps/tejano-trail/tour.json
+++ b/tourmaps/tejano-trail/tour.json
@@ -1,0 +1,203 @@
+{
+  "title": "Tejano Trail",
+  "subtitle": "East Austin · Historical walking tour",
+  "initialCamera": { "center": [-97.728, 30.263], "zoom": 14.5, "pitch": 0, "bearing": 0 },
+  "maxBounds": [[-97.745, 30.252], [-97.710, 30.285]],
+  "geofence": {
+    "defaultRadiusMeters": 45,
+    "triggerOnce": true,
+    "enableHighAccuracy": true,
+    "minMoveMeters": 6
+  },
+  "layers": [
+    {
+      "id": "stops-radius",
+      "type": "circle",
+      "source": "tour-stops",
+      "paint": {
+        "circle-radius": 28,
+        "circle-color": "#b4531a",
+        "circle-opacity": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], 0.08,
+          0.18
+        ],
+        "circle-stroke-color": "#b4531a",
+        "circle-stroke-opacity": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], 0.25,
+          0.45
+        ],
+        "circle-stroke-width": 1.5
+      }
+    },
+    {
+      "id": "stops",
+      "type": "circle",
+      "source": "tour-stops",
+      "paint": {
+        "circle-radius": 8,
+        "circle-color": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], "#2f855a",
+          "#b4531a"
+        ],
+        "circle-stroke-color": "#ffffff",
+        "circle-stroke-width": 2
+      }
+    }
+  ],
+  "stops": [
+    {
+      "id": "plaza-saltillo",
+      "geofence": { "center": [-97.7315, 30.2625] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Plaza Saltillo",
+        "subtitle": "Stop 1 · Gateway to East Austin",
+        "body": "<p>Placeholder narrative — describe Plaza Saltillo as the historical gateway to East Austin's Tejano community. Mention the sister-city relationship with Saltillo, Coahuila.</p>"
+      }
+    },
+    {
+      "id": "juan-in-a-million",
+      "geofence": { "center": [-97.7245, 30.2605] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Juan in a Million",
+        "subtitle": "Stop 2 · Neighborhood institution",
+        "body": "<p>Placeholder narrative — legendary breakfast taco spot on E Cesar Chavez. Replace with real history and family story.</p>"
+      }
+    },
+    {
+      "id": "pan-am-rec",
+      "geofence": { "center": [-97.7285, 30.2610] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Pan American Recreation Center",
+        "subtitle": "Stop 3 · Community hub since 1957",
+        "body": "<p>Placeholder narrative — describe the Pan American's role as a cultural and recreational anchor for East Austin families.</p>"
+      }
+    },
+    {
+      "id": "la-mexicana",
+      "geofence": { "center": [-97.7260, 30.2608] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "La Mexicana Bakery",
+        "subtitle": "Stop 4 · Pan dulce tradition",
+        "body": "<p>Placeholder narrative — family-owned panadería serving East Austin for decades.</p>"
+      }
+    },
+    {
+      "id": "metz-rec",
+      "geofence": { "center": [-97.7222, 30.2622] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Metz Recreation Center",
+        "subtitle": "Stop 5 · Neighborhood gathering place",
+        "body": "<p>Placeholder narrative — Metz Rec Center and the surrounding Holly neighborhood's Tejano history.</p>"
+      }
+    },
+    {
+      "id": "huston-tillotson",
+      "geofence": { "center": [-97.7198, 30.2712] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Huston-Tillotson University",
+        "subtitle": "Stop 6 · Historically Black university, 1875",
+        "body": "<p>Placeholder narrative — shared history of East Austin's Black and Tejano communities, and the university's role in civil rights organizing.</p>"
+      }
+    },
+    {
+      "id": "rosewood-park",
+      "geofence": { "center": [-97.7218, 30.2708] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Rosewood Park",
+        "subtitle": "Stop 7 · Civil rights era gathering place",
+        "body": "<p>Placeholder narrative — Rosewood Park's role in East Austin's movements and family life.</p>"
+      }
+    },
+    {
+      "id": "victory-grill",
+      "geofence": { "center": [-97.7315, 30.2742] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Victory Grill",
+        "subtitle": "Stop 8 · Chitlin' Circuit landmark",
+        "body": "<p>Placeholder narrative — the Victory Grill on E 11th, its history and connections to East Austin's musical heritage.</p>"
+      }
+    },
+    {
+      "id": "kenny-dorhams-backyard",
+      "geofence": { "center": [-97.7308, 30.2742] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Kenny Dorham's Backyard",
+        "subtitle": "Stop 9 · Live music and cultural space",
+        "body": "<p>Placeholder narrative — outdoor venue honoring jazz trumpeter Kenny Dorham and the broader musical heritage of East 11th.</p>"
+      }
+    },
+    {
+      "id": "ebenezer-baptist",
+      "geofence": { "center": [-97.7345, 30.2735] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Ebenezer Baptist Church",
+        "subtitle": "Stop 10 · Historic congregation",
+        "body": "<p>Placeholder narrative — Ebenezer Baptist and East Austin's faith community history.</p>"
+      }
+    },
+    {
+      "id": "texas-state-cemetery",
+      "geofence": { "center": [-97.7280, 30.2720] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Texas State Cemetery",
+        "subtitle": "Stop 11 · Texas history in stone",
+        "body": "<p>Placeholder narrative — resting place of Tejano leaders, politicians, and cultural figures.</p>"
+      }
+    },
+    {
+      "id": "oakwood-cemetery",
+      "geofence": { "center": [-97.7282, 30.2762] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Oakwood Cemetery",
+        "subtitle": "Stop 12 · Austin's oldest burial ground, 1839",
+        "body": "<p>Placeholder narrative — early Tejano Austinites buried here; the cemetery's layered social history.</p>"
+      }
+    },
+    {
+      "id": "sams-bbq",
+      "geofence": { "center": [-97.7248, 30.2755] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Sam's BBQ",
+        "subtitle": "Stop 13 · East 12th Street icon",
+        "body": "<p>Placeholder narrative — long-running East 12th BBQ joint and its place in the neighborhood.</p>"
+      }
+    },
+    {
+      "id": "boggy-creek-trail",
+      "geofence": { "center": [-97.7155, 30.2760] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Boggy Creek Greenbelt",
+        "subtitle": "Stop 14 · Natural spine of East Austin",
+        "body": "<p>Placeholder narrative — Boggy Creek's role in shaping neighborhood boundaries and community green space.</p>"
+      }
+    },
+    {
+      "id": "tejano-trail-marker",
+      "geofence": { "center": [-97.7225, 30.2680] },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Tejano Healthy Walking Trail",
+        "subtitle": "Stop 15 · Trail marker",
+        "body": "<p>Placeholder narrative — closing stop on the trail itself; summarize the walk and link to further reading.</p>",
+        "link": { "href": "/", "text": "Back to City Anatomy →" }
+      }
+    }
+  ]
+}

--- a/tourmaps/tejano-trail/ui.js
+++ b/tourmaps/tejano-trail/ui.js
@@ -1,0 +1,117 @@
+// ui.js — wires DOM elements to the TourEngine via CustomEvents.
+// No tour logic here; all state lives in engine.js.
+
+function initTourUI(engine) {
+  const brandTitle  = document.getElementById('tm-tour-name');
+  const permModal   = document.getElementById('tm-permission');
+  const allowBtn    = document.getElementById('tm-allow-gps');
+  const previewBtn  = document.getElementById('tm-preview');
+  const progressEl  = document.getElementById('tm-progress');
+  const stopsBtn    = document.getElementById('tm-stops-btn');
+  const stopsPanel  = document.getElementById('tm-stops-panel');
+  const stopsList   = document.getElementById('tm-stops-list');
+  const stopsClose  = document.getElementById('tm-stops-close');
+  const recenterBtn = document.getElementById('tm-recenter');
+  const banner      = document.getElementById('tm-banner');
+
+  // ── Populate brand card title ───────────────────────────────────
+  const t = engine.tour;
+  if (t?.title && brandTitle) brandTitle.textContent = t.title;
+
+  // ── Build stops list ────────────────────────────────────────────
+  function renderStopsList() {
+    stopsList.innerHTML = '';
+    engine.stops.forEach((stop, i) => {
+      const li = document.createElement('li');
+      li.className = 'tm-stop-item' + (engine.isVisited(stop.id) ? ' is-visited' : '');
+      li.dataset.id = stop.id;
+      li.innerHTML = `
+        <span class="tm-stop-index">${i + 1}</span>
+        <span class="tm-stop-body">
+          <span class="tm-stop-title">${escapeHTML(stop.popup?.title ?? stop.id)}</span>
+          ${stop.popup?.subtitle ? `<span class="tm-stop-subtitle">${escapeHTML(stop.popup.subtitle)}</span>` : ''}
+        </span>
+        <span class="tm-stop-check" aria-hidden="true">✓</span>
+      `;
+      li.addEventListener('click', () => {
+        engine.triggerStopById(stop.id, 'click');
+        closeStopsPanel();
+      });
+      stopsList.appendChild(li);
+    });
+  }
+  renderStopsList();
+
+  function updateProgress() {
+    const visited = engine.visited.size;
+    const total = engine.stops.length;
+    progressEl.textContent = `${visited} / ${total}`;
+    progressEl.setAttribute('aria-label', `${visited} of ${total} stops visited`);
+  }
+  updateProgress();
+
+  function markStopVisitedInList(id) {
+    const li = stopsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+    if (li) li.classList.add('is-visited');
+  }
+
+  // ── Stops panel open/close ──────────────────────────────────────
+  function openStopsPanel()  { stopsPanel.classList.add('is-open'); }
+  function closeStopsPanel() { stopsPanel.classList.remove('is-open'); }
+
+  stopsBtn.addEventListener('click', openStopsPanel);
+  stopsClose.addEventListener('click', closeStopsPanel);
+
+  // ── Permission modal ────────────────────────────────────────────
+  const urlSimulate = new URLSearchParams(window.location.search).get('simulate') === '1';
+  if (urlSimulate) {
+    permModal.hidden = true;
+    engine.enableSimulateMode();
+    showBanner('Simulate mode — drag the SIM marker onto a stop to trigger its popup.');
+  }
+
+  allowBtn?.addEventListener('click', () => {
+    permModal.hidden = true;
+    engine.requestGeolocation();
+  });
+
+  previewBtn?.addEventListener('click', () => {
+    permModal.hidden = true;
+    engine.enableSimulateMode();
+    showBanner('Preview mode — drag the SIM marker or pick a stop from the list.');
+  });
+
+  // ── Recenter button ─────────────────────────────────────────────
+  recenterBtn.addEventListener('click', () => engine.recenter());
+
+  // ── Banner helper ───────────────────────────────────────────────
+  function showBanner(msg, ms = 6000) {
+    if (!banner) return;
+    banner.textContent = msg;
+    banner.hidden = false;
+    clearTimeout(showBanner._t);
+    if (ms > 0) showBanner._t = setTimeout(() => { banner.hidden = true; }, ms);
+  }
+
+  // ── Listen to engine events ─────────────────────────────────────
+  window.addEventListener('tour:stop-entered', e => {
+    markStopVisitedInList(e.detail.stop.id);
+    updateProgress();
+  });
+
+  window.addEventListener('tour:geolocation-denied', () => {
+    showBanner('Location permission denied — switching to preview mode.', 8000);
+    engine.enableSimulateMode();
+  });
+
+  window.addEventListener('tour:geolocation-unavailable', () => {
+    showBanner('This browser does not support geolocation — using preview mode.', 8000);
+    engine.enableSimulateMode();
+  });
+}
+
+function escapeHTML(str) {
+  return String(str).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}

--- a/tourmaps/template/PLAN.md
+++ b/tourmaps/template/PLAN.md
@@ -1,0 +1,65 @@
+# Tour Maps Template
+
+A geofence-triggered walking-tour experience. Copy this folder to create a new tour.
+
+## What this is
+
+- A full-screen MapLibre map bounded to a single neighborhood.
+- A list of **stops**, each with a circular **geofence** (center + radius).
+- When the user's browser geolocation crosses into a stop's radius, the stop's
+  popup fires automatically (once per stop).
+- Works on desktop too via **simulate mode**: click any stop in the side panel,
+  or add `?simulate=1` to the URL to drag a SIM marker around the map.
+
+## File layout
+
+```
+/my-tour/
+├── index.html          # Scaffolding + MapLibre init. Rarely needs edits.
+├── engine.js           # TourEngine — geofence driver. Don't edit unless extending.
+├── ui.js               # UI controller (permission modal, progress chip, stops panel).
+├── style.css           # Visual styling. Safe to tweak per tour.
+├── tour.json           # ALL content + geofence config. This is what you edit.
+└── data/
+    └── stops.geojson   # Optional. Unused by default — stops layer is built from tour.json.
+```
+
+## Authoring a new tour
+
+1. Copy this `template/` folder to `/tourmaps/<your-tour-id>/`.
+2. Edit `tour.json`:
+   - `title` / `subtitle` — shown in the top-right brand card.
+   - `initialCamera` — where the map starts. Use zoom 14–16 for neighborhood scale.
+   - `maxBounds` — `[[westLng, southLat], [eastLng, northLat]]` bounding box.
+     The camera can't pan outside this.
+   - `geofence.defaultRadiusMeters` — fallback radius for stops that don't specify one.
+   - `stops[]` — each stop has:
+     - `id` (unique string)
+     - `geofence.center` (`[lng, lat]`) and optional `geofence.radiusMeters`
+     - `popup` — same rich schema as storymaps: `title`, `subtitle`, `body` (HTML),
+       `image`, `youtube`, `stats`, `link`.
+3. Register the tour in `/tourmaps/index.json` and `/tourmaps/reports.json`.
+
+## Visual conventions
+
+- **Orange** (`#b4531a`) = unvisited stop + geofence ring.
+- **Green** = visited stop.
+- **Blue pulsing dot** = live GPS position.
+- **Orange SIM marker** = simulate-mode draggable pointer.
+
+## Verification
+
+1. `python3 -m http.server 8000` at repo root.
+2. `http://localhost:8000/tourmaps/<your-tour-id>/`
+3. Click **Preview without GPS** or append `?simulate=1` to the URL.
+4. Drag the SIM marker into a stop's ring → popup should fire, progress chip
+   should tick up, and the stop should turn green in the side panel.
+
+## Extending
+
+- **YouTube videos** in popups: add `youtube: { videoId, startAt, stopAt, mute }`.
+- **Extra map layers** (e.g. the walking route as a line): add entries to
+  `tour.json.layers`. Use `"source": "tour-stops"` to reuse the built-in stops
+  source, or provide a URL/GeoJSON to add a new source.
+- **Non-circular geofences**: would require editing `engine.js` to swap the
+  haversine check for a polygon point-in-polygon test (e.g. Turf.js).

--- a/tourmaps/template/data/stops.geojson
+++ b/tourmaps/template/data/stops.geojson
@@ -1,0 +1,4 @@
+{
+  "type": "FeatureCollection",
+  "features": []
+}

--- a/tourmaps/template/engine.js
+++ b/tourmaps/template/engine.js
@@ -1,0 +1,418 @@
+// TourEngine — drives the /tourmaps/ geofence-triggered walking-tour experience.
+// All content, stop geofences, layers, and popup content come from tour.json.
+// Popups fire when the user's geolocation crosses into a stop's radius, or when
+// the user clicks a stop in the side panel / drags the simulate marker.
+
+class TourEngine {
+  constructor(map) {
+    this.map = map;
+    this.tour = null;
+    this.stops = [];
+    this.visited = new Set();
+
+    this.popup = null;
+    this.ytPlayer = null;
+    this.ytReady = false;
+    this._ytAPIPromise = null;
+    this._ytPollInterval = null;
+
+    this._watchId = null;
+    this._lastCheck = null;         // { lng, lat } of last geofence check
+    this._hereMarker = null;
+    this._simulate = false;
+    this._simMarker = null;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────
+
+  async start(url) {
+    const res = await fetch(url);
+    this.tour = await res.json();
+    this.stops = this.tour.stops ?? [];
+
+    const ic = this.tour.initialCamera;
+    if (ic) {
+      this.map.jumpTo({
+        center: ic.center,
+        zoom: ic.zoom ?? 15,
+        pitch: ic.pitch ?? 0,
+        bearing: ic.bearing ?? 0,
+      });
+    }
+
+    if (Array.isArray(this.tour.maxBounds) && this.tour.maxBounds.length === 2) {
+      this.map.setMaxBounds(this.tour.maxBounds);
+    }
+
+    this._initStopsSource();
+    this._initLayers();
+    this._emit('tour-loaded', { tour: this.tour });
+  }
+
+  requestGeolocation() {
+    if (!('geolocation' in navigator)) {
+      this._emit('geolocation-unavailable', {});
+      return;
+    }
+    const opts = {
+      enableHighAccuracy: this.tour?.geofence?.enableHighAccuracy !== false,
+      maximumAge: 5000,
+      timeout: 20000,
+    };
+    this._watchId = navigator.geolocation.watchPosition(
+      pos => this._onPosition(pos),
+      err => this._onPositionError(err),
+      opts
+    );
+  }
+
+  stopGeolocation() {
+    if (this._watchId != null) {
+      navigator.geolocation.clearWatch(this._watchId);
+      this._watchId = null;
+    }
+  }
+
+  enableSimulateMode(startLngLat) {
+    if (this._simulate) return;
+    this._simulate = true;
+    this.stopGeolocation();
+
+    const el = document.createElement('div');
+    el.className = 'tm-simulate-marker';
+    el.innerHTML = '<span class="tm-simulate-dot"></span><span class="tm-simulate-label">SIM</span>';
+
+    const start = startLngLat ?? this.tour?.initialCamera?.center ?? this.map.getCenter().toArray();
+    this._simMarker = new maplibregl.Marker({ element: el, draggable: true })
+      .setLngLat(start)
+      .addTo(this.map);
+
+    this._simMarker.on('dragend', () => {
+      const { lng, lat } = this._simMarker.getLngLat();
+      this._setSimulatedPosition(lng, lat);
+    });
+
+    this._setSimulatedPosition(start[0], start[1]);
+    this._emit('simulate-enabled', {});
+  }
+
+  triggerStopById(id, source = 'click') {
+    const stop = this.stops.find(s => s.id === id);
+    if (stop) this._triggerStop(stop, source);
+  }
+
+  recenter() {
+    const pos = this._lastCheck;
+    if (!pos) return;
+    this.map.easeTo({ center: [pos.lng, pos.lat], duration: 600 });
+  }
+
+  isVisited(id) {
+    return this.visited.has(id);
+  }
+
+  // ── Geolocation handlers ────────────────────────────────────────
+
+  _onPosition(pos) {
+    const { latitude: lat, longitude: lng, accuracy } = pos.coords;
+    this._updateHereMarker(lng, lat, accuracy);
+
+    const minMove = this.tour?.geofence?.minMoveMeters ?? 5;
+    if (this._lastCheck) {
+      const moved = haversineMeters(this._lastCheck.lng, this._lastCheck.lat, lng, lat);
+      if (moved < minMove) return;
+    }
+    this._lastCheck = { lng, lat };
+    this._checkGeofences(lng, lat, 'gps');
+  }
+
+  _onPositionError(err) {
+    console.warn('TourEngine: geolocation error', err.message);
+    this._emit('geolocation-denied', { error: err.message, code: err.code });
+  }
+
+  _setSimulatedPosition(lng, lat) {
+    this._lastCheck = { lng, lat };
+    this._updateHereMarker(lng, lat, null);
+    this._checkGeofences(lng, lat, 'simulate');
+  }
+
+  _updateHereMarker(lng, lat, accuracy) {
+    if (this._simulate) return; // SIM marker is the "here" marker in simulate mode
+    if (!this._hereMarker) {
+      const el = document.createElement('div');
+      el.className = 'tm-here-marker';
+      el.innerHTML = '<span class="tm-here-pulse"></span><span class="tm-here-dot"></span>';
+      this._hereMarker = new maplibregl.Marker({ element: el })
+        .setLngLat([lng, lat])
+        .addTo(this.map);
+    } else {
+      this._hereMarker.setLngLat([lng, lat]);
+    }
+  }
+
+  _checkGeofences(lng, lat, source) {
+    const defaultRadius = this.tour?.geofence?.defaultRadiusMeters ?? 40;
+    const triggerOnce = this.tour?.geofence?.triggerOnce !== false;
+
+    for (const stop of this.stops) {
+      if (!stop.geofence?.center) continue;
+      const radius = stop.geofence.radiusMeters ?? defaultRadius;
+      const [sLng, sLat] = stop.geofence.center;
+      const d = haversineMeters(lng, lat, sLng, sLat);
+      if (d <= radius) {
+        if (triggerOnce && this.visited.has(stop.id)) continue;
+        this._triggerStop(stop, source);
+      }
+    }
+  }
+
+  // ── Stop trigger ────────────────────────────────────────────────
+
+  _triggerStop(stop, source) {
+    // Clean up any previous popup/video
+    if (this.popup) { this.popup.remove(); this.popup = null; }
+    this._clearYTPoll();
+    if (this.ytPlayer) { try { this.ytPlayer.stopVideo(); } catch (e) {} }
+
+    const center = stop.geofence?.center ?? stop.popup?.lngLat;
+    if (center) {
+      this.map.easeTo({
+        center,
+        zoom: stop.camera?.zoom ?? this.map.getZoom(),
+        pitch: stop.camera?.pitch ?? this.map.getPitch(),
+        bearing: stop.camera?.bearing ?? this.map.getBearing(),
+        duration: 800,
+        padding: { top: 200, bottom: 0, left: 0, right: 0 },
+      });
+    }
+
+    this._showPopup(stop);
+
+    const wasVisited = this.visited.has(stop.id);
+    this.visited.add(stop.id);
+    this._setStopVisitedOnMap(stop.id);
+
+    this._emit('stop-entered', {
+      stop,
+      source,
+      firstVisit: !wasVisited,
+      visitedCount: this.visited.size,
+      totalStops: this.stops.length,
+    });
+  }
+
+  _setStopVisitedOnMap(id) {
+    // Drive the "visited" data-driven styling via feature-state
+    if (!this.map.getSource('tour-stops')) return;
+    this.map.setFeatureState(
+      { source: 'tour-stops', id },
+      { visited: true }
+    );
+  }
+
+  // ── Popup (copied from StoryEngine for visual parity) ───────────
+
+  async _showPopup(stop) {
+    const p = stop.popup;
+    if (!p) return;
+    const lngLat = p.lngLat ?? stop.geofence?.center;
+    if (!lngLat) return;
+
+    const token = Date.now();
+    const html = this._buildPopupHTML(p, token);
+
+    this.popup = new maplibregl.Popup({
+      closeButton: true,
+      closeOnClick: false,
+      anchor: p.anchor ?? 'bottom',
+      offset: p.offset ?? 12,
+      maxWidth: '320px',
+    })
+      .setLngLat(lngLat)
+      .setHTML(html)
+      .addTo(this.map);
+
+    if (p.youtube) {
+      try {
+        await Promise.race([
+          this._loadYouTubeAPI(),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('YT API timeout')), 6000)),
+        ]);
+        const placeholderId = `yt-player-${token}`;
+        await Promise.race([
+          this._createYTPlayer(placeholderId, p.youtube.videoId, p.youtube.startAt, p.youtube.mute),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('YT Player timeout')), 8000)),
+        ]);
+        if (p.youtube.stopAt != null) this._pollYTForStopAt(p.youtube.stopAt, token);
+      } catch (e) {
+        console.warn('TourEngine: YouTube failed.', e.message);
+      }
+    }
+  }
+
+  _buildPopupHTML(p, token) {
+    let html = '<div class="sm-popup">';
+
+    if (p.title || p.subtitle) {
+      html += '<div class="sm-popup-header">';
+      if (p.title) html += `<h3 class="sm-popup-title">${p.title}</h3>`;
+      if (p.subtitle) html += `<p class="sm-popup-subtitle">${p.subtitle}</p>`;
+      html += '</div>';
+    }
+
+    if (p.image?.src) {
+      html += '<figure class="sm-popup-figure">';
+      html += `<img src="${p.image.src}" alt="${p.image.alt ?? ''}" class="sm-popup-img" loading="lazy" />`;
+      if (p.image.caption) html += `<figcaption>${p.image.caption}</figcaption>`;
+      html += '</figure>';
+    }
+
+    if (p.youtube) {
+      html += `<div class="sm-popup-video-wrap"><div id="yt-player-${token}" class="sm-yt-placeholder"></div></div>`;
+    }
+
+    if (p.body) {
+      html += `<div class="sm-popup-body">${p.body}</div>`;
+    }
+
+    if (p.stats?.length) {
+      html += '<table class="sm-popup-stats">';
+      p.stats.forEach(({ label, value }) => {
+        html += `<tr><th>${label}</th><td>${value}</td></tr>`;
+      });
+      html += '</table>';
+    }
+
+    if (p.link?.href) {
+      html += `<a class="sm-popup-link" href="${p.link.href}" target="_blank" rel="noopener noreferrer">${p.link.text ?? 'View →'}</a>`;
+    }
+
+    html += '</div>';
+    return html;
+  }
+
+  // ── Layers ──────────────────────────────────────────────────────
+
+  _initStopsSource() {
+    // Build a FeatureCollection from tour.json stops so authors only edit one file.
+    const features = this.stops
+      .filter(s => s.geofence?.center)
+      .map(s => ({
+        type: 'Feature',
+        id: s.id,
+        properties: {
+          id: s.id,
+          title: s.popup?.title ?? s.id,
+          subtitle: s.popup?.subtitle ?? '',
+          radiusMeters: s.geofence.radiusMeters ?? this.tour?.geofence?.defaultRadiusMeters ?? 40,
+        },
+        geometry: { type: 'Point', coordinates: s.geofence.center },
+      }));
+
+    if (!this.map.getSource('tour-stops')) {
+      this.map.addSource('tour-stops', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features },
+        promoteId: 'id',
+      });
+    }
+  }
+
+  _initLayers() {
+    const layers = this.tour.layers ?? [];
+    layers.forEach(layerDef => {
+      // Built-in virtual source: "tour-stops"
+      const useBuiltIn = layerDef.source === 'tour-stops';
+
+      if (!useBuiltIn && !this.map.getSource(layerDef.id)) {
+        this.map.addSource(layerDef.id, { type: 'geojson', data: layerDef.source });
+      }
+
+      const spec = {
+        id: layerDef.id,
+        type: layerDef.type,
+        source: useBuiltIn ? 'tour-stops' : layerDef.id,
+        paint: layerDef.paint ?? {},
+        layout: { visibility: 'visible', ...(layerDef.layout ?? {}) },
+      };
+      if (layerDef.sourceLayer) spec['source-layer'] = layerDef.sourceLayer;
+      if (layerDef.filter) spec.filter = layerDef.filter;
+
+      if (layerDef.insertBefore && this.map.getLayer(layerDef.insertBefore)) {
+        this.map.addLayer(spec, layerDef.insertBefore);
+      } else {
+        this.map.addLayer(spec);
+      }
+    });
+  }
+
+  // ── YouTube (copied from StoryEngine) ───────────────────────────
+
+  _loadYouTubeAPI() {
+    if (this.ytReady) return Promise.resolve();
+    if (this._ytAPIPromise) return this._ytAPIPromise;
+    this._ytAPIPromise = new Promise(resolve => {
+      window.onYouTubeIframeAPIReady = () => { this.ytReady = true; resolve(); };
+      const s = document.createElement('script');
+      s.src = 'https://www.youtube.com/iframe_api';
+      document.head.appendChild(s);
+    });
+    return this._ytAPIPromise;
+  }
+
+  _createYTPlayer(containerId, videoId, startAt, mute) {
+    if (this.ytPlayer) {
+      try { this.ytPlayer.destroy(); } catch (e) {}
+      this.ytPlayer = null;
+    }
+    return new Promise((resolve, reject) => {
+      const el = document.getElementById(containerId);
+      if (!el) { reject(new Error('YT placeholder not found')); return; }
+      this.ytPlayer = new YT.Player(containerId, {
+        videoId,
+        playerVars: {
+          autoplay: 1, start: startAt ?? 0, mute: mute !== false ? 1 : 0,
+          controls: 1, rel: 0, modestbranding: 1, playsinline: 1,
+        },
+        events: {
+          onReady: event => { event.target.playVideo(); resolve(event.target); },
+          onError: event => { reject(new Error(`YT player error: ${event.data}`)); },
+        },
+      });
+    });
+  }
+
+  _pollYTForStopAt(stopAt, token) {
+    this._clearYTPoll();
+    this._ytPollInterval = setInterval(() => {
+      if (!this.ytPlayer?.getCurrentTime) return;
+      try {
+        const t = this.ytPlayer.getCurrentTime();
+        if (t >= stopAt) { this._clearYTPoll(); }
+      } catch (e) { this._clearYTPoll(); }
+    }, 250);
+  }
+
+  _clearYTPoll() {
+    if (this._ytPollInterval) { clearInterval(this._ytPollInterval); this._ytPollInterval = null; }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────
+
+  _emit(name, detail) {
+    window.dispatchEvent(new CustomEvent(`tour:${name}`, { detail }));
+  }
+}
+
+// Great-circle distance in metres between two lng/lat pairs.
+function haversineMeters(aLng, aLat, bLng, bLat) {
+  const R = 6371000;
+  const toRad = d => d * Math.PI / 180;
+  const dLat = toRad(bLat - aLat);
+  const dLng = toRad(bLng - aLng);
+  const s = Math.sin(dLat / 2) ** 2
+          + Math.cos(toRad(aLat)) * Math.cos(toRad(bLat))
+          * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(s));
+}

--- a/tourmaps/template/index.html
+++ b/tourmaps/template/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <base target="_blank" />
+  <title>Tour Map · City Anatomy</title>
+  <link href="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+
+  <!-- Full-screen map -->
+  <div id="map"></div>
+
+  <!-- Brand card — top-right -->
+  <div class="tm-brand-card">
+    <a href="/" class="tm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
+    <p id="tm-tour-name" class="tm-brand-title"></p>
+  </div>
+
+  <!-- Banner (hints / errors) -->
+  <div id="tm-banner" class="tm-banner" hidden></div>
+
+  <!-- Progress chip — bottom-center -->
+  <div id="tm-progress" class="tm-progress-chip" aria-live="polite">0 / 0</div>
+
+  <!-- Stops panel toggle — bottom-left -->
+  <button id="tm-stops-btn" class="tm-icon-btn" aria-label="Show stops list" title="Stops">
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M3 6h18v2H3zM3 11h18v2H3zM3 16h18v2H3z"/>
+    </svg>
+  </button>
+
+  <!-- Recenter button — bottom-left, above stops -->
+  <button id="tm-recenter" class="tm-icon-btn" aria-label="Recenter map on my location" title="Recenter">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M12 2v3M12 19v3M2 12h3M19 12h3"/>
+    </svg>
+  </button>
+
+  <!-- Stops side panel -->
+  <aside id="tm-stops-panel" class="tm-stops-panel" aria-label="Tour stops">
+    <div class="tm-stops-panel-header">
+      <h2>Tour stops</h2>
+      <button id="tm-stops-close" class="tm-stops-close" aria-label="Close stops list">×</button>
+    </div>
+    <ul id="tm-stops-list" class="tm-stops-list"></ul>
+  </aside>
+
+  <!-- Permission modal — first-paint overlay -->
+  <div id="tm-permission" class="tm-permission-modal" role="dialog" aria-modal="true" aria-labelledby="tm-perm-title">
+    <div class="tm-permission-card">
+      <h2 id="tm-perm-title">Walking tour</h2>
+      <p>This tour uses your location to trigger stops as you walk. Popups appear when you enter each point of interest. You can also preview the tour without sharing your location.</p>
+      <div class="tm-actions">
+        <button id="tm-preview"   class="tm-btn">Preview without GPS</button>
+        <button id="tm-allow-gps" class="tm-btn is-primary">Allow location</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://unpkg.com/maplibre-gl@3.6.0/dist/maplibre-gl.js"></script>
+  <script src="engine.js"></script>
+  <script src="ui.js"></script>
+  <script>
+    const map = new maplibregl.Map({
+      container: 'map',
+      style: 'https://tiles.openfreemap.org/styles/liberty',
+      center: [-97.7431, 30.2672],
+      zoom: 14,
+      pitch: 0,
+      bearing: 0,
+      antialias: true
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
+
+    const engine = new TourEngine(map);
+
+    map.on('load', () => {
+      // 3D buildings (same aesthetic as storymaps)
+      const layers = map.getStyle().layers;
+      let labelLayerId;
+      for (const layer of layers) {
+        if (layer.type === 'symbol' && layer.layout['text-field']) {
+          labelLayerId = layer.id;
+          break;
+        }
+      }
+      map.addLayer({
+        id: '3d-buildings',
+        source: 'openmaptiles',
+        'source-layer': 'building',
+        filter: ['==', ['get', 'extrude'], 'true'],
+        type: 'fill-extrusion',
+        minzoom: 15,
+        paint: {
+          'fill-extrusion-color': '#aaa',
+          'fill-extrusion-height': ['get', 'render_height'],
+          'fill-extrusion-base': ['get', 'render_min_height'],
+          'fill-extrusion-opacity': 0.55
+        }
+      }, labelLayerId);
+
+      engine.start('tour.json').then(() => {
+        initTourUI(engine);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/tourmaps/template/style.css
+++ b/tourmaps/template/style.css
@@ -1,0 +1,510 @@
+/* ── CSS variables (light + dark) ─────────────────────────────── */
+:root {
+  --background: #f5f7fa;
+  --text: #1c1c28;
+  --accent: #b4531a;
+  --accent-light: #e8895a;
+  --surface: #ffffff;
+  --muted: #6f7780;
+  --border: #e1e6ee;
+  --shadow: rgba(15, 25, 45, 0.12);
+  --here: #1a73ff;
+  --sim: #b4531a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0e1117;
+    --text: #f5f7fa;
+    --accent: #e8895a;
+    --accent-light: #f4b48b;
+    --surface: #161b23;
+    --muted: #c0c7d1;
+    --border: #2a3040;
+    --shadow: rgba(0, 0, 0, 0.45);
+    --here: #6ea9ff;
+  }
+}
+
+/* ── Page reset — full-screen map ─────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0;
+  width: 100%; height: 100%;
+  overflow: hidden;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background: var(--background);
+}
+
+#map { position: fixed; inset: 0; width: 100%; height: 100%; }
+
+/* ── Brand card — top-right ─────────────────────────────────── */
+.tm-brand-card {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 20;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 10px 14px;
+  box-shadow: 0 8px 24px var(--shadow);
+  max-width: 240px;
+}
+.tm-brand-link {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-decoration: none;
+  margin-bottom: 4px;
+  transition: color 0.15s ease;
+}
+.tm-brand-link:hover { color: var(--accent); }
+.tm-brand-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+/* ── Permission modal ────────────────────────────────────────── */
+.tm-permission-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: color-mix(in srgb, var(--background) 70%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.tm-permission-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 22px 22px 18px;
+  max-width: 380px;
+  box-shadow: 0 20px 60px var(--shadow);
+  text-align: center;
+}
+.tm-permission-card h2 {
+  margin: 0 0 6px;
+  font-size: 1.15rem;
+  color: var(--text);
+}
+.tm-permission-card p {
+  margin: 0 0 16px;
+  font-size: 0.9rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.tm-permission-card .tm-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.tm-btn {
+  flex: 1 1 120px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 14px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  background: var(--surface);
+  color: var(--text);
+}
+.tm-btn:hover { transform: translateY(-1px); border-color: var(--accent); }
+.tm-btn.is-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.tm-btn.is-primary:hover {
+  background: color-mix(in srgb, var(--accent) 85%, #000);
+  color: #fff;
+}
+
+/* ── Progress chip — bottom-center ───────────────────────────── */
+.tm-progress-chip {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text);
+  box-shadow: 0 4px 14px var(--shadow);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.tm-progress-chip::before {
+  content: '';
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+/* ── Round icon buttons (stops, recenter) ────────────────────── */
+.tm-icon-btn {
+  position: fixed;
+  z-index: 20;
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: var(--text);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 6px 16px var(--shadow);
+  padding: 0;
+  transition: transform 0.12s ease, border-color 0.15s ease;
+}
+.tm-icon-btn:hover {
+  transform: scale(1.05);
+  border-color: var(--accent);
+}
+.tm-icon-btn svg { width: 20px; height: 20px; }
+
+#tm-stops-btn    { bottom: 28px; left: 20px; }
+#tm-recenter     { bottom: 84px; left: 20px; }
+
+/* ── Stops side panel ─────────────────────────────────────────── */
+.tm-stops-panel {
+  position: fixed;
+  top: 0; bottom: 0;
+  left: 0;
+  z-index: 40;
+  width: min(360px, 85vw);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  box-shadow: 8px 0 24px var(--shadow);
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+.tm-stops-panel.is-open { transform: translateX(0); }
+
+.tm-stops-panel-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.tm-stops-panel-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+.tm-stops-close {
+  border: none;
+  background: transparent;
+  font-size: 1.3rem;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px 8px;
+}
+.tm-stops-close:hover { color: var(--text); }
+
+.tm-stops-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  overflow-y: auto;
+  flex: 1;
+}
+.tm-stop-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.tm-stop-item:hover {
+  background: color-mix(in srgb, var(--border) 35%, transparent);
+  border-left-color: var(--accent);
+}
+.tm-stop-index {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.tm-stop-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.tm-stop-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tm-stop-subtitle {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tm-stop-check {
+  opacity: 0;
+  color: var(--accent);
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+.tm-stop-item.is-visited .tm-stop-check { opacity: 1; }
+.tm-stop-item.is-visited .tm-stop-index {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── "You are here" marker ───────────────────────────────────── */
+.tm-here-marker {
+  position: relative;
+  width: 22px; height: 22px;
+  display: flex; align-items: center; justify-content: center;
+  pointer-events: none;
+}
+.tm-here-dot {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--here);
+  border: 3px solid #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  z-index: 2;
+}
+.tm-here-pulse {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--here);
+  opacity: 0.35;
+  animation: tm-pulse 1.6s ease-out infinite;
+}
+@keyframes tm-pulse {
+  0%   { transform: scale(0.5); opacity: 0.5; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+/* ── Simulate mode marker ────────────────────────────────────── */
+.tm-simulate-marker {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: grab;
+  pointer-events: auto;
+}
+.tm-simulate-marker:active { cursor: grabbing; }
+.tm-simulate-dot {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--sim);
+  border: 3px solid #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+}
+.tm-simulate-label {
+  margin-top: 4px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: #fff;
+  background: var(--sim);
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* ── Banner (simulate / denied hints) ────────────────────────── */
+.tm-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  background: var(--text);
+  color: var(--background);
+  padding: 8px 16px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 99px;
+  box-shadow: 0 6px 18px var(--shadow);
+  max-width: 80vw;
+  text-align: center;
+}
+
+/* ── MapLibre popup overrides (match storymaps) ─────────────── */
+.maplibregl-popup-content {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0;
+  box-shadow: 0 12px 32px var(--shadow);
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  min-width: 220px;
+  max-width: 320px;
+  overflow: hidden;
+}
+.maplibregl-popup-tip { border-top-color: var(--surface) !important; }
+.maplibregl-popup-close-button {
+  position: absolute;
+  top: 0; right: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+  padding: 8px 11px;
+  line-height: 1;
+  border-radius: 0 14px 0 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.maplibregl-popup-close-button:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--border) 40%, transparent);
+}
+
+/* ── Rich popup inner layout (same class names as storymaps) ── */
+.sm-popup { padding: 14px 16px 16px; }
+.sm-popup-header { margin-bottom: 10px; padding-right: 20px; }
+.sm-popup-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+.sm-popup-subtitle {
+  margin: 3px 0 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.sm-popup-figure { margin: -14px -16px 12px; padding: 0; }
+.sm-popup-img {
+  width: 100%;
+  display: block;
+  max-height: 160px;
+  object-fit: cover;
+}
+.sm-popup-figure figcaption {
+  font-size: 0.72rem;
+  color: var(--muted);
+  padding: 4px 10px 2px;
+  text-align: right;
+}
+.sm-popup-video-wrap {
+  margin: 0 -16px 12px;
+  background: #000;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  position: relative;
+}
+.sm-yt-placeholder,
+.sm-popup-video-wrap iframe {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  border: none;
+  display: block;
+}
+.sm-popup-body {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.55;
+  margin-bottom: 10px;
+}
+.sm-popup-body p { margin: 0 0 6px; }
+.sm-popup-body p:last-child { margin-bottom: 0; }
+.sm-popup-stats {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  margin-bottom: 12px;
+  border-top: 1px solid var(--border);
+}
+.sm-popup-stats tr + tr td,
+.sm-popup-stats tr + tr th { border-top: 1px solid var(--border); }
+.sm-popup-stats th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 5px 8px 5px 0;
+  white-space: nowrap;
+  width: 42%;
+}
+.sm-popup-stats td {
+  text-align: right;
+  color: var(--text);
+  padding: 5px 0;
+  font-weight: 700;
+}
+.sm-popup-link {
+  display: block;
+  text-align: center;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.1s ease;
+  margin-top: 2px;
+}
+.sm-popup-link:hover {
+  background: color-mix(in srgb, var(--accent) 80%, #000);
+  transform: translateY(-1px);
+  color: #fff;
+}
+
+/* ── Mobile tweaks ───────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .tm-brand-card { top: 12px; right: 12px; padding: 8px 12px; max-width: 180px; }
+  .tm-brand-title { font-size: 0.85rem; }
+  .maplibregl-popup-content { max-width: 280px; }
+  #tm-stops-btn  { bottom: 24px; left: 14px; }
+  #tm-recenter   { bottom: 76px; left: 14px; }
+  .tm-progress-chip { bottom: 24px; padding: 6px 14px; font-size: 0.8rem; }
+}

--- a/tourmaps/template/tour.json
+++ b/tourmaps/template/tour.json
@@ -1,0 +1,62 @@
+{
+  "title": "Tour name",
+  "subtitle": "Neighborhood · Walking tour",
+  "initialCamera": { "center": [-97.7431, 30.2672], "zoom": 15, "pitch": 0, "bearing": 0 },
+  "maxBounds": [[-97.755, 30.255], [-97.730, 30.280]],
+  "geofence": {
+    "defaultRadiusMeters": 40,
+    "triggerOnce": true,
+    "enableHighAccuracy": true,
+    "minMoveMeters": 5
+  },
+  "layers": [
+    {
+      "id": "stops-radius",
+      "type": "circle",
+      "source": "tour-stops",
+      "paint": {
+        "circle-radius": 26,
+        "circle-color": "#b4531a",
+        "circle-opacity": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], 0.08,
+          0.18
+        ],
+        "circle-stroke-color": "#b4531a",
+        "circle-stroke-opacity": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], 0.25,
+          0.45
+        ],
+        "circle-stroke-width": 1.5
+      }
+    },
+    {
+      "id": "stops",
+      "type": "circle",
+      "source": "tour-stops",
+      "paint": {
+        "circle-radius": 8,
+        "circle-color": [
+          "case",
+          ["boolean", ["feature-state", "visited"], false], "#2f855a",
+          "#b4531a"
+        ],
+        "circle-stroke-color": "#ffffff",
+        "circle-stroke-width": 2
+      }
+    }
+  ],
+  "stops": [
+    {
+      "id": "stop-1",
+      "geofence": { "center": [-97.7431, 30.2672], "radiusMeters": 40 },
+      "popup": {
+        "anchor": "bottom",
+        "title": "Stop 1",
+        "subtitle": "First point of interest",
+        "body": "<p>Replace this with a short narrative for stop 1.</p>"
+      }
+    }
+  ]
+}

--- a/tourmaps/template/ui.js
+++ b/tourmaps/template/ui.js
@@ -1,0 +1,117 @@
+// ui.js — wires DOM elements to the TourEngine via CustomEvents.
+// No tour logic here; all state lives in engine.js.
+
+function initTourUI(engine) {
+  const brandTitle  = document.getElementById('tm-tour-name');
+  const permModal   = document.getElementById('tm-permission');
+  const allowBtn    = document.getElementById('tm-allow-gps');
+  const previewBtn  = document.getElementById('tm-preview');
+  const progressEl  = document.getElementById('tm-progress');
+  const stopsBtn    = document.getElementById('tm-stops-btn');
+  const stopsPanel  = document.getElementById('tm-stops-panel');
+  const stopsList   = document.getElementById('tm-stops-list');
+  const stopsClose  = document.getElementById('tm-stops-close');
+  const recenterBtn = document.getElementById('tm-recenter');
+  const banner      = document.getElementById('tm-banner');
+
+  // ── Populate brand card title ───────────────────────────────────
+  const t = engine.tour;
+  if (t?.title && brandTitle) brandTitle.textContent = t.title;
+
+  // ── Build stops list ────────────────────────────────────────────
+  function renderStopsList() {
+    stopsList.innerHTML = '';
+    engine.stops.forEach((stop, i) => {
+      const li = document.createElement('li');
+      li.className = 'tm-stop-item' + (engine.isVisited(stop.id) ? ' is-visited' : '');
+      li.dataset.id = stop.id;
+      li.innerHTML = `
+        <span class="tm-stop-index">${i + 1}</span>
+        <span class="tm-stop-body">
+          <span class="tm-stop-title">${escapeHTML(stop.popup?.title ?? stop.id)}</span>
+          ${stop.popup?.subtitle ? `<span class="tm-stop-subtitle">${escapeHTML(stop.popup.subtitle)}</span>` : ''}
+        </span>
+        <span class="tm-stop-check" aria-hidden="true">✓</span>
+      `;
+      li.addEventListener('click', () => {
+        engine.triggerStopById(stop.id, 'click');
+        closeStopsPanel();
+      });
+      stopsList.appendChild(li);
+    });
+  }
+  renderStopsList();
+
+  function updateProgress() {
+    const visited = engine.visited.size;
+    const total = engine.stops.length;
+    progressEl.textContent = `${visited} / ${total}`;
+    progressEl.setAttribute('aria-label', `${visited} of ${total} stops visited`);
+  }
+  updateProgress();
+
+  function markStopVisitedInList(id) {
+    const li = stopsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+    if (li) li.classList.add('is-visited');
+  }
+
+  // ── Stops panel open/close ──────────────────────────────────────
+  function openStopsPanel()  { stopsPanel.classList.add('is-open'); }
+  function closeStopsPanel() { stopsPanel.classList.remove('is-open'); }
+
+  stopsBtn.addEventListener('click', openStopsPanel);
+  stopsClose.addEventListener('click', closeStopsPanel);
+
+  // ── Permission modal ────────────────────────────────────────────
+  const urlSimulate = new URLSearchParams(window.location.search).get('simulate') === '1';
+  if (urlSimulate) {
+    permModal.hidden = true;
+    engine.enableSimulateMode();
+    showBanner('Simulate mode — drag the SIM marker onto a stop to trigger its popup.');
+  }
+
+  allowBtn?.addEventListener('click', () => {
+    permModal.hidden = true;
+    engine.requestGeolocation();
+  });
+
+  previewBtn?.addEventListener('click', () => {
+    permModal.hidden = true;
+    engine.enableSimulateMode();
+    showBanner('Preview mode — drag the SIM marker or pick a stop from the list.');
+  });
+
+  // ── Recenter button ─────────────────────────────────────────────
+  recenterBtn.addEventListener('click', () => engine.recenter());
+
+  // ── Banner helper ───────────────────────────────────────────────
+  function showBanner(msg, ms = 6000) {
+    if (!banner) return;
+    banner.textContent = msg;
+    banner.hidden = false;
+    clearTimeout(showBanner._t);
+    if (ms > 0) showBanner._t = setTimeout(() => { banner.hidden = true; }, ms);
+  }
+
+  // ── Listen to engine events ─────────────────────────────────────
+  window.addEventListener('tour:stop-entered', e => {
+    markStopVisitedInList(e.detail.stop.id);
+    updateProgress();
+  });
+
+  window.addEventListener('tour:geolocation-denied', () => {
+    showBanner('Location permission denied — switching to preview mode.', 8000);
+    engine.enableSimulateMode();
+  });
+
+  window.addEventListener('tour:geolocation-unavailable', () => {
+    showBanner('This browser does not support geolocation — using preview mode.', 8000);
+    engine.enableSimulateMode();
+  });
+}
+
+function escapeHTML(str) {
+  return String(str).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}


### PR DESCRIPTION
Parallel to /storymaps/, driven by browser geolocation instead of a scripted
autoplay timeline. Popups fire when the user enters a stop's circular
geofence; desktop users can use Preview mode (?simulate=1 or button) with a
draggable SIM marker and click-to-trigger from the stops side panel.

- template/: starter kit (TourEngine, UI, styles, tour.json schema, PLAN.md)
- tejano-trail/: first demo with 15 placeholder East Austin stops for the
  user to edit with real coordinates and narratives
- index.json / reports.json: registry mirroring /storymaps/ conventions

https://claude.ai/code/session_01RM43r1LcyCJjUiHCCYzV1C