### PR TITLE
Maps: unified brand/social/nav layout + satellite+3D on by default + chatmap GPS zoom

### DIFF
--- a/homelesschat/pubchat-engine.js
+++ b/homelesschat/pubchat-engine.js
@@ -112,6 +112,10 @@ class PubchatEngine {
   _onPosition(pos) {
     const { latitude: lat, longitude: lng, accuracy } = pos.coords;
     this._updateHereMarker(lng, lat);
+    if (!this._firstFix) {
+      this._firstFix = true;
+      this.map.flyTo({ center: [lng, lat], zoom: 17, duration: 1200 });
+    }
     this._lastCheck = { lng, lat };
     this._emit('position-update', { lng, lat, accuracy, source: 'gps' });
     this._checkHotspots(lng, lat, 'gps');

--- a/librarychat/pubchat-engine.js
+++ b/librarychat/pubchat-engine.js
@@ -112,6 +112,10 @@ class PubchatEngine {
   _onPosition(pos) {
     const { latitude: lat, longitude: lng, accuracy } = pos.coords;
     this._updateHereMarker(lng, lat);
+    if (!this._firstFix) {
+      this._firstFix = true;
+      this.map.flyTo({ center: [lng, lat], zoom: 17, duration: 1200 });
+    }
     this._lastCheck = { lng, lat };
     this._emit('position-update', { lng, lat, accuracy, source: 'gps' });
     this._checkHotspots(lng, lat, 'gps');

--- a/pubchat/pubchat-engine.js
+++ b/pubchat/pubchat-engine.js
@@ -112,6 +112,10 @@ class PubchatEngine {
   _onPosition(pos) {
     const { latitude: lat, longitude: lng, accuracy } = pos.coords;
     this._updateHereMarker(lng, lat);
+    if (!this._firstFix) {
+      this._firstFix = true;
+      this.map.flyTo({ center: [lng, lat], zoom: 17, duration: 1200 });
+    }
     this._lastCheck = { lng, lat };
     this._emit('position-update', { lng, lat, accuracy, source: 'gps' });
     this._checkHotspots(lng, lat, 'gps');

--- a/storymaps/PoolOpenings/index.html
+++ b/storymaps/PoolOpenings/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/PoolOpenings/style.css
+++ b/storymaps/PoolOpenings/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-bike-shops/index.html
+++ b/storymaps/austin-bike-shops/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-bike-shops/style.css
+++ b/storymaps/austin-bike-shops/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-chambers/index.html
+++ b/storymaps/austin-chambers/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-chambers/style.css
+++ b/storymaps/austin-chambers/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-golf-courses/index.html
+++ b/storymaps/austin-golf-courses/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-golf-courses/style.css
+++ b/storymaps/austin-golf-courses/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-horseback-riding/index.html
+++ b/storymaps/austin-horseback-riding/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-horseback-riding/style.css
+++ b/storymaps/austin-horseback-riding/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-neighborhoods/index.html
+++ b/storymaps/austin-neighborhoods/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-neighborhoods/style.css
+++ b/storymaps/austin-neighborhoods/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-ps5-bundles/index.html
+++ b/storymaps/austin-ps5-bundles/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-ps5-bundles/style.css
+++ b/storymaps/austin-ps5-bundles/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/austin-vintage-guitar/index.html
+++ b/storymaps/austin-vintage-guitar/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/austin-vintage-guitar/style.css
+++ b/storymaps/austin-vintage-guitar/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/storymaps/template/index.html
+++ b/storymaps/template/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right (title + back link combined) -->
+  <!-- Brand card — bottom-center pill (title + back link) -->
   <div class="sm-brand-card">
     <a href="/" class="sm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="sm-story-name" class="sm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav -->
+  <footer class="sm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Play/Pause button — bottom-left -->
   <button id="sm-play-btn" class="sm-play-btn" aria-label="Pause story" title="Pause">
@@ -30,7 +41,7 @@
     </svg>
   </button>
 
-  <!-- Scene dot indicators — bottom-center -->
+  <!-- Scene dot indicators — bottom-center (nav bar) -->
   <nav id="sm-dots" class="sm-dots" aria-label="Story scenes"></nav>
 
   <!-- Next button — right center -->
@@ -50,7 +61,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 10,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -58,7 +69,8 @@
     const engine = new StoryEngine(map);
 
     map.on('load', () => {
-      // 3D buildings (same as homepage)
+      initBasemapControls();
+
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -74,6 +86,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -89,6 +102,57 @@
         }
       });
     });
+
+    function initBasemapControls() {
+      map.addSource('satellite', {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+      });
+
+      map.addLayer({
+        id: 'satellite-layer',
+        type: 'raster',
+        source: 'satellite',
+        layout: { visibility: 'visible' }
+      }, map.getStyle().layers[1].id);
+
+      map.addControl({
+        onAdd() {
+          this._container = document.createElement('div');
+          this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+
+          this._satBtn = document.createElement('button');
+          this._satBtn.className = 'satellite-btn active';
+          this._satBtn.textContent = 'Satellite';
+          this._satBtn.onclick = () => {
+            const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
+            map.setLayoutProperty('satellite-layer', 'visibility', on ? 'none' : 'visible');
+            this._satBtn.classList.toggle('active', !on);
+          };
+          this._container.appendChild(this._satBtn);
+
+          this._viewBtn = document.createElement('button');
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
+          this._viewBtn.onclick = () => {
+            const tilted = map.getPitch() > 5;
+            const nextPitch = tilted ? 0 : 45;
+            map.easeTo({ pitch: nextPitch, duration: 600 });
+            if (map.getLayer('3d-buildings')) {
+              map.setLayoutProperty('3d-buildings', 'visibility', tilted ? 'none' : 'visible');
+            }
+            this._viewBtn.textContent = tilted ? '3D' : '2D';
+            this._viewBtn.classList.toggle('active', !tilted);
+          };
+          this._container.appendChild(this._viewBtn);
+
+          return this._container;
+        },
+        onRemove() { this._container.parentNode.removeChild(this._container); }
+      }, 'top-left');
+    }
   </script>
 </body>
 </html>

--- a/storymaps/template/style.css
+++ b/storymaps/template/style.css
@@ -43,31 +43,37 @@ html, body {
   height: 100%;
 }
 
-/* ── Brand card — top-right (title + back link combined) ───────── */
+/* ── Brand card — bottom-center pill (title bar) ───────────────── */
 .sm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 220px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 
 .sm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .sm-brand-link:hover { color: var(--accent); }
@@ -77,8 +83,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ───────────────────────────── */
+.sm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.sm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.sm-social-footer a:hover { color: var(--accent); }
+.sm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Play/Pause button — bottom-left ─────────────────────────── */
 .sm-play-btn {
@@ -113,10 +150,10 @@ html, body {
   flex-shrink: 0;
 }
 
-/* ── Scene dot indicators — bottom-center ────────────────────── */
+/* ── Scene dot indicators — bottom-center (nav bar) ──────────── */
 .sm-dots {
   position: fixed;
-  bottom: 40px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -188,6 +225,25 @@ html, body {
   flex-shrink: 0;
 }
 
+/* ── Basemap toggle buttons ──────────────────────────────────── */
+.maplibregl-ctrl-group button.satellite-btn,
+.maplibregl-ctrl-group button.view-toggle-btn {
+  width: auto;
+  padding: 0 10px;
+  height: 29px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #fff;
+  color: #333;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-group button.satellite-btn:hover,
+.maplibregl-ctrl-group button.view-toggle-btn:hover { background: #f0f0f0; }
+.maplibregl-ctrl-group button.satellite-btn.active,
+.maplibregl-ctrl-group button.view-toggle-btn.active {
+  background: #d0e8ff;
+  color: #003d7a;
+}
 
 /* ── MapLibre popup overrides ────────────────────────────────── */
 .maplibregl-popup-content {
@@ -346,12 +402,15 @@ html, body {
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
   .sm-brand-card {
-    top: 12px;
-    right: 12px;
-    padding: 8px 12px;
-    max-width: 180px;
+    bottom: 96px;
+    padding: 5px 12px;
+    gap: 8px;
   }
-  .sm-brand-title { font-size: 0.85rem; }
+  .sm-brand-title { font-size: 0.88rem; }
+
+  .sm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .sm-social-footer a { width: 20px; height: 20px; }
+  .sm-social-footer svg { width: 16px; height: 16px; }
 
   .maplibregl-popup-content {
     max-width: 280px;
@@ -363,7 +422,7 @@ html, body {
   }
 
   .sm-dots {
-    bottom: 28px;
+    bottom: 14px;
     gap: 6px;
     padding: 6px 12px;
   }

--- a/tourmaps/template/index.html
+++ b/tourmaps/template/index.html
@@ -13,11 +13,22 @@
   <!-- Full-screen map -->
   <div id="map"></div>
 
-  <!-- Brand card — top-right -->
+  <!-- Brand card — bottom-center pill (title bar) -->
   <div class="tm-brand-card">
     <a href="/" class="tm-brand-link" target="_top">City Anatomy <span aria-hidden="true">↗</span></a>
     <p id="tm-tour-name" class="tm-brand-title"></p>
   </div>
+
+  <!-- Social footer — above nav bar -->
+  <footer class="tm-social-footer" aria-label="Social links">
+    <a href="#" aria-label="YouTube"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.5 12 3.5 12 3.5s-7.5 0-9.4.6A3 3 0 0 0 .5 6.2 31.5 31.5 0 0 0 0 12a31.5 31.5 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.6 9.4.6 9.4.6s7.5 0 9.4-.6a3 3 0 0 0 2.1-2.1A31.5 31.5 0 0 0 24 12a31.5 31.5 0 0 0-.5-5.8zM9.6 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+    <a href="#" aria-label="X (Twitter)"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.2 2.25h3.5l-7.7 8.8L23 21.75h-7.1l-5.5-7.2-6.3 7.2H.6l8.2-9.4L.4 2.25H7.7l5 6.6 5.5-6.6zm-1.2 17.5h2L7.1 4.3H5L17 19.75z"/></svg></a>
+    <a href="#" aria-label="Facebook"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4A12 12 0 0 0 24 12z"/></svg></a>
+    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.2c3.2 0 3.6 0 4.9.1 1.2.1 1.8.2 2.2.4.6.2 1 .5 1.4.9.4.4.7.8.9 1.4.2.4.4 1.1.4 2.2.1 1.3.1 1.6.1 4.8s0 3.6-.1 4.9c-.1 1.2-.2 1.8-.4 2.2-.2.6-.5 1-.9 1.4-.4.4-.8.7-1.4.9-.4.2-1.1.4-2.2.4-1.3.1-1.6.1-4.9.1s-3.6 0-4.9-.1c-1.2-.1-1.8-.2-2.2-.4a3.9 3.9 0 0 1-1.4-.9c-.4-.4-.7-.8-.9-1.4-.2-.4-.4-1.1-.4-2.2-.1-1.3-.1-1.6-.1-4.9s0-3.6.1-4.9c.1-1.2.2-1.8.4-2.2.2-.6.5-1 .9-1.4.4-.4.8-.7 1.4-.9.4-.2 1.1-.4 2.2-.4 1.3-.1 1.6-.1 4.9-.1zM12 0C8.7 0 8.3 0 7.1.1 5.8.1 4.9.3 4.1.6c-.8.3-1.5.7-2.2 1.4A6 6 0 0 0 .6 4.1C.3 4.9.1 5.8.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.1 1.3.2 2.2.6 2.9.3.8.7 1.5 1.4 2.2.7.7 1.3 1.1 2.2 1.4.8.3 1.6.5 2.9.6 1.2.1 1.6.1 4.8.1s3.7 0 4.9-.1c1.3-.1 2.2-.2 2.9-.6.8-.3 1.5-.7 2.2-1.4.7-.7 1.1-1.3 1.4-2.2.3-.8.5-1.6.6-2.9.1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.1-1.3-.2-2.2-.6-2.9-.3-.8-.7-1.5-1.4-2.2A6 6 0 0 0 19.9.6C19.1.3 18.2.1 16.9.1 15.7 0 15.3 0 12 0zm0 5.8a6.2 6.2 0 1 0 0 12.4A6.2 6.2 0 0 0 12 5.8zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.4-10.9a1.4 1.4 0 1 0 0 2.9 1.4 1.4 0 0 0 0-2.9z"/></svg></a>
+    <a href="#" aria-label="Reddit"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.1 13.8c0 .2.1.3.1.5 0 2.6-3 4.7-6.7 4.7-3.7 0-6.7-2.1-6.7-4.7 0-.2 0-.3.1-.5a1.6 1.6 0 0 1-.6-1.3 1.6 1.6 0 0 1 2.7-1.2 8.2 8.2 0 0 1 4.3-1.4l.8-3.8a.3.3 0 0 1 .4-.3l2.7.6a1.1 1.1 0 1 1-.1.6l-2.5-.5-.7 3.4a8.1 8.1 0 0 1 4.2 1.4 1.6 1.6 0 0 1 2.7 1.2c0 .5-.2 1-.7 1.3zM9.3 13a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm5.4 0a1.3 1.3 0 1 0 0 2.6 1.3 1.3 0 0 0 0-2.6zm-5.1 4.5c-.1-.1 0-.3.1-.3a6.4 6.4 0 0 0 4.6 0c.2-.1.3 0 .3.2s-.1.2-.2.3a6.7 6.7 0 0 1-4.6 0c-.1 0-.2-.1-.2-.2z"/></svg></a>
+    <a href="#" aria-label="Patreon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.4.5a8.1 8.1 0 1 0 0 16.2 8.1 8.1 0 0 0 0-16.2zM.5.5h3.8v23H.5z"/></svg></a>
+    <a href="#" aria-label="Discord"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A18.5 18.5 0 0 0 15.7 3a13 13 0 0 0-.6 1.2 17.2 17.2 0 0 0-5.1 0A12 12 0 0 0 9.4 3a18.5 18.5 0 0 0-4.6 1.4A19.5 19.5 0 0 0 1.5 19a18.7 18.7 0 0 0 5.7 2.9 14 14 0 0 0 1.2-2 12 12 0 0 1-1.9-.9l.5-.4a13.3 13.3 0 0 0 11.4 0l.5.4a12 12 0 0 1-1.9.9 14 14 0 0 0 1.2 2 18.6 18.6 0 0 0 5.7-2.9A19.4 19.4 0 0 0 20.3 4.4zM8.3 16c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3zm7.4 0c-1.1 0-2-1-2-2.3s.9-2.3 2-2.3 2 1 2 2.3-.9 2.3-2 2.3z"/></svg></a>
+  </footer>
 
   <!-- Banner (hints / errors) -->
   <div id="tm-banner" class="tm-banner" hidden></div>
@@ -35,7 +46,7 @@
     </span>
   </button>
 
-  <!-- Progress chip — bottom-center -->
+  <!-- Progress chip — bottom-center (nav bar) -->
   <div id="tm-progress" class="tm-progress-chip" aria-live="polite">0 / 0</div>
 
   <!-- Stops panel toggle — bottom-left -->
@@ -84,7 +95,7 @@
       style: 'https://tiles.openfreemap.org/styles/liberty',
       center: [-97.7431, 30.2672],
       zoom: 14,
-      pitch: 0,
+      pitch: 45,
       bearing: 0,
       antialias: true
     });
@@ -96,7 +107,6 @@
     map.on('load', () => {
       initBasemapControls();
 
-      // 3D buildings (same aesthetic as storymaps)
       const layers = map.getStyle().layers;
       let labelLayerId;
       for (const layer of layers) {
@@ -112,7 +122,7 @@
         filter: ['==', ['get', 'extrude'], 'true'],
         type: 'fill-extrusion',
         minzoom: 15,
-        layout: { visibility: 'none' },
+        layout: { visibility: 'visible' },
         paint: {
           'fill-extrusion-color': '#aaa',
           'fill-extrusion-height': ['get', 'render_height'],
@@ -126,8 +136,6 @@
       });
     });
 
-    // Combined basemap controls — Satellite toggle + 2D/3D pitch toggle,
-    // stacked in one ctrl-group. Same pattern as /apps/citywide/*.
     function initBasemapControls() {
       map.addSource('satellite', {
         type: 'raster',
@@ -140,7 +148,7 @@
         id: 'satellite-layer',
         type: 'raster',
         source: 'satellite',
-        layout: { visibility: 'none' }
+        layout: { visibility: 'visible' }
       }, map.getStyle().layers[1].id);
 
       map.addControl({
@@ -148,9 +156,8 @@
           this._container = document.createElement('div');
           this._container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
 
-          // Satellite toggle
           this._satBtn = document.createElement('button');
-          this._satBtn.className = 'satellite-btn';
+          this._satBtn.className = 'satellite-btn active';
           this._satBtn.textContent = 'Satellite';
           this._satBtn.onclick = () => {
             const on = map.getLayoutProperty('satellite-layer', 'visibility') === 'visible';
@@ -159,10 +166,9 @@
           };
           this._container.appendChild(this._satBtn);
 
-          // 2D/3D toggle (label reflects what tapping will do)
           this._viewBtn = document.createElement('button');
-          this._viewBtn.className = 'view-toggle-btn';
-          this._viewBtn.textContent = '3D';
+          this._viewBtn.className = 'view-toggle-btn active';
+          this._viewBtn.textContent = '2D';
           this._viewBtn.onclick = () => {
             const tilted = map.getPitch() > 5;
             const nextPitch = tilted ? 0 : 45;

--- a/tourmaps/template/style.css
+++ b/tourmaps/template/style.css
@@ -39,30 +39,36 @@ html, body {
 
 #map { position: fixed; inset: 0; width: 100%; height: 100%; }
 
-/* ── Brand card — top-right ─────────────────────────────────── */
+/* ── Brand card — bottom-center pill (title bar) ────────────── */
 .tm-brand-card {
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: 104px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 20;
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 10px 14px;
+  border-radius: 999px;
+  padding: 6px 14px;
   box-shadow: 0 8px 24px var(--shadow);
-  max-width: 240px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  max-width: calc(100vw - 32px);
+  white-space: nowrap;
 }
 .tm-brand-link {
-  display: block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
   text-decoration: none;
-  margin-bottom: 4px;
   transition: color 0.15s ease;
 }
 .tm-brand-link:hover { color: var(--accent); }
@@ -71,8 +77,39 @@ html, body {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+/* ── Social footer — above nav bar ──────────────────────────── */
+.tm-social-footer {
+  position: fixed;
+  bottom: 54px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px var(--shadow);
+}
+.tm-social-footer a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.tm-social-footer a:hover { color: var(--accent); }
+.tm-social-footer svg { width: 18px; height: 18px; }
 
 /* ── Permission modal ────────────────────────────────────────── */
 .tm-permission-modal {
@@ -141,10 +178,10 @@ html, body {
   color: #fff;
 }
 
-/* ── Progress chip — bottom-center ───────────────────────────── */
+/* ── Progress chip — bottom-center (nav bar) ─────────────────── */
 .tm-progress-chip {
   position: fixed;
-  bottom: 28px;
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -192,8 +229,8 @@ html, body {
 }
 .tm-icon-btn svg { width: 20px; height: 20px; }
 
-#tm-stops-btn    { bottom: 28px; left: 20px; }
-#tm-recenter     { bottom: 84px; left: 20px; }
+#tm-stops-btn    { bottom: 16px; left: 20px; }
+#tm-recenter     { bottom: 72px; left: 20px; }
 
 /* ── Stops side panel ─────────────────────────────────────────── */
 .tm-stops-panel {
@@ -716,12 +753,15 @@ html, body {
 
 /* ── Mobile tweaks ───────────────────────────────────────────── */
 @media (max-width: 600px) {
-  .tm-brand-card { top: 12px; right: 12px; padding: 8px 12px; max-width: 180px; }
-  .tm-brand-title { font-size: 0.85rem; }
+  .tm-brand-card { bottom: 96px; padding: 5px 12px; gap: 8px; }
+  .tm-brand-title { font-size: 0.88rem; }
+  .tm-social-footer { gap: 10px; padding: 6px 12px; bottom: 50px; }
+  .tm-social-footer a { width: 20px; height: 20px; }
+  .tm-social-footer svg { width: 16px; height: 16px; }
   .maplibregl-popup-content { max-width: 280px; }
   #tm-stops-btn  { bottom: 24px; left: 14px; }
   #tm-recenter   { bottom: 76px; left: 14px; }
-  .tm-progress-chip { bottom: 24px; padding: 6px 14px; font-size: 0.8rem; }
+  .tm-progress-chip { bottom: 14px; padding: 6px 14px; font-size: 0.8rem; }
   .tm-compass { top: 52px; padding: 6px 14px 6px 8px; }
   .tm-compass-label { max-width: 50vw; font-size: 0.78rem; }
 }


### PR DESCRIPTION
Storymaps + tourmaps:
- Brand card moved from top-right to bottom-center pill (title bar)
- Social media bar added above nav bar (scene dots / progress chip)
- Layout order bottom-to-top: nav bar → social footer → title bar
- Satellite layer on by default (active state)
- Initial pitch set to 45° (3D on by default), 3D buildings visible
- Satellite + 2D/3D toggle buttons wired up in all storymaps (new)

Chatmaps (pubchat / librarychat / homelesschat):
- On first real GPS fix, fly to user's position at zoom 17 (block level)

https://claude.ai/code/session_01NL16CyPpPe1QCayheftLoi