### PR TITLE
Add documentation for citywide apps architecture

### DIFF
--- a/apps/citywide/CLAUDE.md
+++ b/apps/citywide/CLAUDE.md
@@ -1,0 +1,22 @@
+# apps/citywide
+
+This folder contains the map apps that power the **Product Intelligence Reports**. Each subfolder is a self-contained app served at its own URL slug (e.g. `/apps/citywide/austin-bike-shops/`).
+
+## Apps are identical and modular
+
+All apps share the same `app.js`, `style.css`, `index.html`, and favicon files — these are never modified per-app. The only files that differ between apps are:
+
+| File | Purpose |
+|------|---------|
+| `config.js` | All app-specific settings (title, theme, filters, columns, map center, etc.) |
+| `data.geojson` | The location data for that app's subject |
+
+## Creating a new app
+
+Copy the `template/` folder and rename it to your desired URL slug, then edit only `config.js` and `data.geojson`.
+
+```
+cp -r apps/citywide/template apps/citywide/your-new-slug
+```
+
+All `config.js` fields are documented inline. The `nameField` value must match a property key in `data.geojson`.


### PR DESCRIPTION
## Summary
Added comprehensive documentation for the `apps/citywide` folder structure and development workflow.

## Changes
- Created `CLAUDE.md` documenting the modular architecture of citywide map apps
- Documented the shared files (`app.js`, `style.css`, `index.html`, favicon) that remain consistent across all apps
- Clarified which files are app-specific (`config.js` and `data.geojson`)
- Provided clear instructions for creating new apps using the template folder pattern
- Included a reference table explaining the purpose of each configurable file

## Details
This documentation serves as a guide for developers creating new Product Intelligence Report apps. It establishes the convention that all apps are identical except for their configuration and data files, making the codebase more maintainable and reducing duplication. The template-based approach is now explicitly documented with copy-paste instructions.

https://claude.ai/code/session_01VKoT9fLjnHfSFXPBVaH1vA